### PR TITLE
Expand endregion comments to match the start of region comments.

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -95,6 +95,6 @@
 
         </profile>
     </profiles>
-    <!--endregion-->
+    <!--endregion Phase 16: prepare-package-->
 
 </project>

--- a/liftwizard-example/pom.xml
+++ b/liftwizard-example/pom.xml
@@ -546,7 +546,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--endregion-->
+            <!--endregion Phase 3: generate-sources-->
 
         </plugins>
     </build>
@@ -563,7 +563,7 @@
                 </plugins>
             </build>
         </profile>
-        <!--endregion-->
+        <!--endregion Phase 17: package-->
 
         <!--region Phase 21: verify-->
         <profile>
@@ -579,7 +579,7 @@
                 </plugins>
             </build>
         </profile>
-        <!--endregion-->
+        <!--endregion Phase 21: verify-->
 
     </profiles>
 

--- a/liftwizard-generator-plugins/liftwizard-generator-reladomo-code-plugin/pom.xml
+++ b/liftwizard-generator-plugins/liftwizard-generator-reladomo-code-plugin/pom.xml
@@ -82,7 +82,7 @@
                     <goalPrefix>liftwizard-generator-reladomo-code</goalPrefix>
                 </configuration>
             </plugin>
-            <!--endregion-->
+            <!--endregion Phase 3: generate-sources through Phase 17: package-->
         </plugins>
     </build>
 </project>

--- a/liftwizard-generator-plugins/liftwizard-generator-reladomo-database-plugin/pom.xml
+++ b/liftwizard-generator-plugins/liftwizard-generator-reladomo-database-plugin/pom.xml
@@ -97,7 +97,7 @@
                     <goalPrefix>liftwizard-generator-reladomo-database</goalPrefix>
                 </configuration>
             </plugin>
-            <!--endregion-->
+            <!--endregion Phase 3: generate-sources through Phase 17: package-->
         </plugins>
     </build>
 </project>

--- a/liftwizard-generator-plugins/liftwizard-generator-xsd2bean-plugin/pom.xml
+++ b/liftwizard-generator-plugins/liftwizard-generator-xsd2bean-plugin/pom.xml
@@ -90,7 +90,7 @@
                     <goalPrefix>liftwizard-generator-xsd2bean</goalPrefix>
                 </configuration>
             </plugin>
-            <!--endregion-->
+            <!--endregion Phase 3: generate-sources through Phase 17: package-->
         </plugins>
     </build>
 </project>

--- a/liftwizard-logging/liftwizard-config-logging-filter-janino/pom.xml
+++ b/liftwizard-logging/liftwizard-config-logging-filter-janino/pom.xml
@@ -153,5 +153,5 @@
             </build>
         </profile>
     </profiles>
-    <!--endregion-->
+    <!--endregion Phase 21: verify-->
 </project>

--- a/liftwizard-maven-build/liftwizard-bom/pom.xml
+++ b/liftwizard-maven-build/liftwizard-bom/pom.xml
@@ -85,7 +85,7 @@
                 <artifactId>liftwizard-principal-firebase</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-auth-->
 
             <!--region liftwizard-bundle-->
             <dependency>
@@ -153,7 +153,7 @@
                 <artifactId>liftwizard-bundle-system-properties</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-bundle-->
 
             <!--region liftwizard-clock-->
             <dependency>
@@ -271,7 +271,7 @@
                 <artifactId>liftwizard-configuration-factory-json</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-config-->
 
             <!--region liftwizard-generator-plugins-->
             <dependency>
@@ -291,7 +291,7 @@
                 <artifactId>liftwizard-generator-xsd2bean-plugin</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-generator-plugins-->
 
             <!--region liftwizard-graphql-->
             <dependency>
@@ -359,7 +359,7 @@
                 <artifactId>liftwizard-graphql-reladomo-meta</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-graphql-->
 
             <!--region liftwizard-jackson-->
             <dependency>
@@ -385,7 +385,7 @@
                 <artifactId>liftwizard-jackson-pretty-printer</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-jackson-->
 
             <!--region liftwizard-logging-->
             <dependency>
@@ -513,7 +513,7 @@
                 <artifactId>liftwizard-metrics-reporter-slf4j</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-logging-->
 
             <!--region liftwizard-reladomo-->
             <dependency>
@@ -665,7 +665,7 @@
                 <artifactId>liftwizard-task-reladomo-clear-cache</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-reladomo-->
 
             <!--region liftwizard-servlet-->
             <dependency>
@@ -715,7 +715,7 @@
                 <artifactId>liftwizard-servlet-single-page-redirect-filter</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-servlet-->
 
             <!--region liftwizard-test-->
             <dependency>
@@ -795,7 +795,7 @@
                 <artifactId>liftwizard-junit-rule-match-json</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-test-->
 
             <!--region liftwizard-utility-->
             <dependency>
@@ -821,7 +821,7 @@
                 <artifactId>liftwizard-rewrite</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-utility-->
 
             <!--region liftwizard-uuid-->
             <dependency>
@@ -847,7 +847,7 @@
                 <artifactId>liftwizard-config-uuid</artifactId>
                 <version>2.1.21-SNAPSHOT</version>
             </dependency>
-            <!--endregion-->
+            <!--endregion liftwizard-uuid-->
 
         </dependencies>
     </dependencyManagement>

--- a/liftwizard-maven-build/liftwizard-parent-build/pom.xml
+++ b/liftwizard-maven-build/liftwizard-parent-build/pom.xml
@@ -58,9 +58,7 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>3.1.0</version>
                 </plugin>
-                <!--endregion-->
 
-                <!--region Phase 3: generate-sources-->
                 <plugin>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr4-maven-plugin</artifactId>
@@ -79,7 +77,7 @@
                         </execution>
                     </executions>
                 </plugin>
-                <!--endregion-->
+                <!--endregion Phase 3: generate-sources-->
 
                 <!--region Phase 3: generate-sources through Phase 17: package-->
                 <plugin>
@@ -101,7 +99,7 @@
                         </execution>
                     </executions>
                 </plugin>
-                <!--endregion-->
+                <!--endregion Phase 3: generate-sources through Phase 17: package-->
 
                 <!--region Phase 4: process-sources-->
                 <plugin>
@@ -109,7 +107,7 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.6.0</version>
                 </plugin>
-                <!--endregion-->
+                <!--endregion Phase 4: process-sources-->
 
                 <!--region Phase 7: compile-->
                 <plugin>
@@ -124,7 +122,7 @@
                         </annotationProcessorPaths>
                     </configuration>
                 </plugin>
-                <!--endregion-->
+                <!--endregion Phase 7: compile-->
 
             </plugins>
         </pluginManagement>
@@ -237,7 +235,7 @@
                 </pluginManagement>
             </build>
         </profile>
-        <!--endregion-->
+        <!--endregion No phase-->
 
         <!--region Phase 1: validate-->
         <profile>
@@ -270,7 +268,7 @@
                 </plugins>
             </build>
         </profile>
-        <!--endregion-->
+        <!--endregion Phase 1: validate-->
 
         <!--region Phase 16: prepare-package-->
         <profile>
@@ -289,7 +287,7 @@
                 </plugins>
             </build>
         </profile>
-        <!--endregion-->
+        <!--endregion Phase 16: prepare-package-->
 
         <!--region Phase 17: package-->
         <profile>
@@ -337,7 +335,7 @@
                 </pluginManagement>
             </build>
         </profile>
-        <!--endregion-->
+        <!--endregion Phase 17: package-->
 
     </profiles>
 

--- a/liftwizard-reladomo/liftwizard-reladomo-operation-grammar/pom.xml
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-grammar/pom.xml
@@ -43,7 +43,7 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
             </plugin>
-            <!--endregion-->
+            <!--endregion Phase 3: generate-sources-->
 
         </plugins>
     </build>

--- a/liftwizard-reladomo/liftwizard-reladomo-simulated-sequence/pom.xml
+++ b/liftwizard-reladomo/liftwizard-reladomo-simulated-sequence/pom.xml
@@ -95,7 +95,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--endregion-->
+            <!--endregion Phase 3: generate-sources-->
 
             <!--region Phase 4: process-sources-->
             <plugin>
@@ -117,7 +117,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--endregion-->
+            <!--endregion Phase 4: process-sources-->
 
         </plugins>
     </build>


### PR DESCRIPTION
Not strictly necessary, but very nice to have when working in the IDE and reordering the xml manually.