### PR TITLE
Move Checkstyle rule JavadocParagraph from "Formatting" to "Formatting Strict" profile.

### DIFF
--- a/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-formatting-strict.xml
+++ b/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-formatting-strict.xml
@@ -95,6 +95,13 @@
         </module>
         <!--endregion-->
 
+        <!--region Javadoc-->
+        <!--https://checkstyle.sourceforge.io/checks/javadoc/index.html-->
+        <module name="JavadocParagraph">
+            <property name="allowNewlineParagraph" value="true" />
+        </module>
+        <!--endregion-->
+
         <!--region Whitespace-->
         <!--https://checkstyle.sourceforge.io/checks/whitespace/index.html-->
         <module name="MatchXpath">

--- a/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-formatting.xml
+++ b/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-formatting.xml
@@ -129,9 +129,6 @@
         <!--region Javadoc-->
         <!--https://checkstyle.sourceforge.io/checks/javadoc/index.html-->
         <module name="JavadocTagContinuationIndentation" />
-        <module name="JavadocParagraph">
-            <property name="allowNewlineParagraph" value="true" />
-        </module>
         <!--endregion-->
 
         <!--region Whitespace-->


### PR DESCRIPTION
This rule conflicts with Google Java Format's style.