### PR TITLE
Remove Checkstyle rule IllegalIdentifierName which bans using keywords as identifiers.

### DIFF
--- a/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-semantics.xml
+++ b/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-semantics.xml
@@ -330,7 +330,6 @@
             <property name="format" value="(^[A-Z][a-zA-Z0-9]*$)|(^[A-Z][a-zA-Z0-9_]*Test$)" />
         </module>
         <module name="PatternVariableName" />
-        <module name="IllegalIdentifierName" />
         <!--endregion-->
 
         <!--region Regexp-->


### PR DESCRIPTION
https://checkstyle.org/checks/naming/illegalidentifiername.html

With no configuration, the default pattern is `"(?i)^(?!(record\|yield\|var\|permits\|sealed)$).+$"`

The problem is that this rejects code like `String record = "record";`

All new keywords in Java are explicitly allowed as identifiers, so this rule rejects valid code, and I see no advantage of keeping it on.