### PR TITLE
Configure actions/cache with fewer unique cache keys.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,10 +17,9 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-test-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
-            maven-test-
             maven-
 
       - uses: twosigma/maven-cache-cleaner@v1
@@ -43,10 +42,9 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-coverage-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
-            maven-coverage-
             maven-
 
       - uses: twosigma/maven-cache-cleaner@v1
@@ -79,10 +77,9 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-enforcer-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
-            maven-enforcer-
             maven-
 
       - uses: twosigma/maven-cache-cleaner@v1
@@ -106,10 +103,9 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-dependency-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
-            maven-dependency-
             maven-
 
       - uses: twosigma/maven-cache-cleaner@v1
@@ -133,10 +129,9 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-javadoc-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
-            maven-javadoc-
             maven-
 
       - uses: twosigma/maven-cache-cleaner@v1
@@ -320,10 +315,9 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-reproducible-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
-            maven-reproducible-
             maven-
 
       - uses: twosigma/maven-cache-cleaner@v1
@@ -355,7 +349,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-formats-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-
@@ -387,7 +381,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-java-sort-imports-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-
@@ -419,7 +413,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-java-unused-imports-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-
@@ -451,7 +445,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-java-cleanthat-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-
@@ -483,7 +477,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-sql-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-
@@ -515,7 +509,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-pom-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-
@@ -547,7 +541,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-markdown-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-
@@ -579,7 +573,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-json-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-
@@ -611,7 +605,7 @@ jobs:
 
       - uses: actions/cache@v4
         with:
-          key: maven-spotless-yaml-${{ hashFiles('**/pom.xml') }}
+          key: maven-spotless-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
           restore-keys: |
             maven-spotless-


### PR DESCRIPTION
Group up all the jobs that run `mvn verify` or `mvn spotless:check` to share one cache key for each group.