### PR TITLE
Run npx in offline mode.

### DIFF
--- a/.just/console.just
+++ b/.just/console.just
@@ -61,9 +61,15 @@ ANSI_BG_BRIGHT_MAGENTA := `tput setab 13`
 ANSI_BG_BRIGHT_CYAN := `tput setab 14`
 ANSI_BG_BRIGHT_WHITE := `tput setab 15`
 
-@_run cmd:
-    echo "{{ANSI_BOLD}}Running command: {{ANSI_NORMAL}}{{ cmd }}{{ANSI_NORMAL}}"
-    eval "$(echo "{{ cmd }}" | npx --yes strip-ansi-cli)"
+_run cmd:
+   #!/usr/bin/env bash
+   set -Eeu
+   offline_flag=""
+   if [ -n "$(npm cache ls strip-ansi-cli)" ]; then
+       offline_flag="--offline"
+   fi
+   echo "{{ANSI_BOLD}}Running command: {{ANSI_NORMAL}}{{ cmd }}{{ANSI_NORMAL}}"
+   eval "$(echo "{{ cmd }}" | npx ${offline_flag} --yes strip-ansi-cli)"
 
 @demo-console-colors:
     #!/usr/bin/env bash


### PR DESCRIPTION
This won't affect developers working with a strong internet connection, but `npx` is quite slow over a tethered connection.