### PR TITLE
Update errorprone profile default settings

### DIFF
--- a/liftwizard-maven-build/liftwizard-profile-parent/pom.xml
+++ b/liftwizard-maven-build/liftwizard-profile-parent/pom.xml
@@ -676,7 +676,10 @@
                             <compilerArgs>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
-                                <arg>-Xplugin:ErrorProne</arg>
+                                <arg>-Xplugin:ErrorProne \
+                                -XepDisableWarningsInGeneratedCode \
+                                -Xep:CanIgnoreReturnValueSuggester:OFF \
+                                -Xep:NullableOnContainingClass:OFF</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
Update the default settings of the errorprone profile. 

I can't put the arguments in new 
`<arg> setting </arg>`: this errors out with something along these lines:

```
Compilation failure
error: invalid flag: -XepDisableWarningsInGeneratedCode -Xep:CanIgnoreReturnValueSuggester:OFF -Xep:NullableOnContainingClass:OFF
```