### PR TITLE
Reduce CheckStyle severity for two rules.

### DIFF
--- a/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-formatting-strict.xml
+++ b/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-formatting-strict.xml
@@ -69,11 +69,6 @@
         </module>
         <!--endregion-->
 
-        <!--region Coding-->
-        <!--https://checkstyle.sourceforge.io/checks/coding/index.html-->
-        <module name="UnnecessaryParentheses" />
-        <!--endregion-->
-
         <!--region Imports-->
         <!--https://checkstyle.sourceforge.io/checks/imports/index.html-->
         <module name="CustomImportOrder">

--- a/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-semantics-strict.xml
+++ b/liftwizard-utility/liftwizard-checkstyle/src/main/resources/checkstyle-configuration-liftwizard-semantics-strict.xml
@@ -114,7 +114,11 @@
             <property name="ignoreSetter" value="true" />
             <property name="setterCanReturnItsClass" value="true" />
         </module>
-        <module name="UnusedLocalVariable" />
+        <module name="UnusedLocalVariable">
+            <!-- Set to warning because ErrorProne recommends using variable name 'unused' for unused variables,
+                 but CheckStyle's UnusedLocalVariable rule still flags it as an error by default -->
+            <property name="severity" value="warning" />
+        </module>
         <module name="DeclarationOrder" />
         <module name="ExplicitInitialization" />
         <!--endregion-->


### PR DESCRIPTION
- Delete overly strict rule UnnecessaryParentheses which conflicts with errorprone recommendations.
- Set UnusedLocalVariable checkstyle rule severity to warning to avoid conflict with errorprone.