### PR TITLE
Fix ECImplFactoryToApiFactory shadowing same-package impl classes.

### DIFF
--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/ECImplFactoryToApiFactory.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/ECImplFactoryToApiFactory.java
@@ -87,6 +87,15 @@ public class ECImplFactoryToApiFactory extends Recipe {
 				return fa;
 			}
 
+			String implPackage = implClassName.substring(0, implClassName.lastIndexOf('.'));
+			J.CompilationUnit cu = getCursor().firstEnclosingOrThrow(J.CompilationUnit.class);
+			if (cu.getPackageDeclaration() != null) {
+				String filePackage = cu.getPackageDeclaration().getExpression().printTrimmed(getCursor());
+				if (implPackage.equals(filePackage)) {
+					return fa;
+				}
+			}
+
 			String apiClassName = implClassName.replace(".impl.factory.", ".api.factory.");
 			JavaType.FullyQualified apiType = JavaType.ShallowClass.build(apiClassName);
 

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/ECImplFactoryToApiFactoryTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/ECImplFactoryToApiFactoryTest.java
@@ -121,6 +121,29 @@ class ECImplFactoryToApiFactoryTest implements RewriteTest {
 	}
 
 	@Test
+	void doNotTransformWhenFileIsInImplFactoryPackage() {
+		this.rewriteRun(
+				java(
+					"""
+					package org.eclipse.collections.impl.factory;
+
+					import java.util.Set;
+
+					public class SetsTest {
+					    void factoryUsage() {
+					        var set = Sets.mutable.empty();
+					    }
+
+					    void utilityUsage(Set<String> a, Set<String> b) {
+					        Set<String> union = Sets.union(a, b);
+					    }
+					}
+					"""
+				)
+			);
+	}
+
+	@Test
 	void doNotTransformStaticUtilityMethods() {
 		this.rewriteRun(
 				java(


### PR DESCRIPTION
When a file is in the org.eclipse.collections.impl.factory package, the impl factory class (e.g. Sets) is accessible without an import. Adding an API import would shadow it, breaking calls to utility methods like Sets.union() that only exist on the impl class.