### PR TITLE
Remove dropwizard-metrics-ui dependency and MetricsUIBundle registration.

### DIFF
--- a/liftwizard-application/pom.xml
+++ b/liftwizard-application/pom.xml
@@ -107,12 +107,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.marmelo.dropwizard</groupId>
-            <artifactId>dropwizard-metrics-ui</artifactId>
-            <version>1.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
         </dependency>

--- a/liftwizard-application/src/main/java/io/liftwizard/dropwizard/application/AbstractLiftwizardApplication.java
+++ b/liftwizard-application/src/main/java/io/liftwizard/dropwizard/application/AbstractLiftwizardApplication.java
@@ -38,7 +38,6 @@ import io.liftwizard.dropwizard.configuration.uuid.UUIDSupplierFactoryProvider;
 import io.liftwizard.dropwizard.healthcheck.reladomo.ReladomoHealthCheck;
 import io.liftwizard.dropwizard.task.reladomo.clear.cache.ReladomoClearCacheTask;
 import io.liftwizard.reladomo.rollback.ReladomoRollbackCommand;
-import org.marmelo.dropwizard.metrics.bundles.MetricsUIBundle;
 
 public abstract class AbstractLiftwizardApplication<
 	T extends Configuration & UUIDSupplierFactoryProvider & ClockFactoryProvider
@@ -88,7 +87,6 @@ public abstract class AbstractLiftwizardApplication<
 		var redirectBundle = new RedirectBundle(httpsRedirect);
 		bootstrap.addBundle(redirectBundle);
 		bootstrap.addBundle(new UUIDBundle());
-		bootstrap.addBundle(new MetricsUIBundle("/dashboard/*"));
 	}
 
 	protected void initializeBundles(@Nonnull Bootstrap<T> bootstrap) {}


### PR DESCRIPTION
The library is unmaintained (last release 2014) and has no Dropwizard 3-compatible release. The /dashboard/* endpoint it served is unused.