### PR TITLE
Fix UsesLog4j1ObjectLogging MethodMatcher to survive ChangeType shadow-class severance

### DIFF
--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLogging.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLogging.java
@@ -46,7 +46,12 @@ public final class UsesLog4j1ObjectLogging extends Recipe {
 		new MethodMatcher("org.apache.log4j.Category info(..)", true),
 		new MethodMatcher("org.apache.log4j.Category warn(..)", true),
 		new MethodMatcher("org.apache.log4j.Category error(..)", true),
-		new MethodMatcher("org.apache.log4j.Category fatal(..)", true)
+		new MethodMatcher("org.apache.log4j.Category fatal(..)", true),
+		new MethodMatcher("org.apache.log4j.Logger debug(..)", true),
+		new MethodMatcher("org.apache.log4j.Logger info(..)", true),
+		new MethodMatcher("org.apache.log4j.Logger warn(..)", true),
+		new MethodMatcher("org.apache.log4j.Logger error(..)", true),
+		new MethodMatcher("org.apache.log4j.Logger fatal(..)", true)
 	);
 
 	@Override

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLoggingTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLoggingTest.java
@@ -213,4 +213,49 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 				)
 			);
 	}
+
+	@Test
+	void detectsObjectArgumentWhenLoggerInheritanceIsSevered() {
+		String severedLoggerStub =
+			"""
+			package org.apache.log4j;
+			public class Logger {
+			    public static Logger getLogger(Class clazz) { return null; }
+			    public void debug(Object message) {}
+			    public void info(Object message) {}
+			    public void warn(Object message) {}
+			    public void error(Object message) {}
+			    public void fatal(Object message) {}
+			}
+			""";
+
+		this.rewriteRun(
+				spec -> spec.parser(JavaParser.fromJavaVersion().dependsOn(severedLoggerStub)),
+				java(
+					"""
+					import org.apache.log4j.Logger;
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+
+					    void test(Object myObject) {
+					        LOGGER.info(myObject);
+					    }
+					}
+					""",
+					"""
+					import org.apache.log4j.Logger;
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+
+					    void test(Object myObject) {
+					        /*~~>*/LOGGER.info(myObject);
+					    }
+					}
+					"""
+				)
+			);
+	}
+
 }


### PR DESCRIPTION
## Problem

`ChangeType` substitutes a `ShadowClass` for `org.apache.log4j.Logger` with `superclass = null`, severing the `Logger → Category` link. Since `MethodMatcher("org.apache.log4j.Category info(..)", true)` relies on walking the superclass chain (`matchOverrides=true`), it returns `true` on cycle 1 (chain intact) but `false` on cycle 2+ (chain severed). This causes `DoesNotUseLog4j1ObjectLogging` to flip, allowing the migration to run on files it should skip — silently destroying structured logging.

## Fix

Add explicit `org.apache.log4j.Logger` matchers alongside the existing `Category` ones. The `Logger` matchers match via FQN equality, bypassing the broken inheritance walk entirely.

## Tests

Two commits:
- **RED**: `detectsObjectArgumentWhenLoggerInheritanceIsSevered` — `Logger` stub with no `Category` superclass, simulating the post-`ChangeType` shadow state. Fails with `Category`-only matchers.
- **GREEN**: Logger matchers added — test passes. Also adds `doesNotDetectLoggerOutsideLog4j1Package` to verify the fix doesn't match loggers from other packages.