### PR TITLE
Bump org.openrewrite:rewrite-bom and rewrite-java-17 to 8.81.7

### DIFF
--- a/liftwizard-generator-plugins/liftwizard-generator-rewrite-plugin/pom.xml
+++ b/liftwizard-generator-plugins/liftwizard-generator-rewrite-plugin/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>org.openrewrite</groupId>
                 <artifactId>rewrite-bom</artifactId>
-                <version>8.78.6</version>
+                <version>8.81.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/liftwizard-generator-plugins/liftwizard-generator-rewrite/pom.xml
+++ b/liftwizard-generator-plugins/liftwizard-generator-rewrite/pom.xml
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>org.openrewrite</groupId>
                 <artifactId>rewrite-bom</artifactId>
-                <version>8.78.6</version>
+                <version>8.81.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/liftwizard-utility/liftwizard-rewrite/pom.xml
+++ b/liftwizard-utility/liftwizard-rewrite/pom.xml
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>org.openrewrite</groupId>
                 <artifactId>rewrite-bom</artifactId>
-                <version>8.79.1</version>
+                <version>8.81.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -340,7 +340,7 @@
                     <dependency>
                         <groupId>org.openrewrite</groupId>
                         <artifactId>rewrite-java-17</artifactId>
-                        <version>8.81.1</version>
+                        <version>8.81.7</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/JCFSortedMapToMutableSortedMapTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/JCFSortedMapToMutableSortedMapTest.java
@@ -58,7 +58,6 @@ class JCFSortedMapToMutableSortedMapTest extends AbstractEclipseCollectionsTest 
 					""",
 					"""
 					import java.util.List;
-					import java.util.SortedMap;
 					import org.eclipse.collections.api.factory.SortedMaps;
 					import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 					import org.eclipse.collections.impl.map.sorted.mutable.TreeSortedMap;

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/JCFSortedSetToMutableSortedSetTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/JCFSortedSetToMutableSortedSetTest.java
@@ -57,7 +57,6 @@ class JCFSortedSetToMutableSortedSetTest extends AbstractEclipseCollectionsTest 
 					}
 					""",
 					"""
-					import java.util.SortedSet;
 					import java.util.List;
 					import org.eclipse.collections.api.factory.SortedSets;
 					import org.eclipse.collections.api.set.sorted.MutableSortedSet;


### PR DESCRIPTION
Updates rewrite-bom from 8.78.6 / 8.79.1 to 8.81.7 across the three poms that import it, and rewrite-java-17 from 8.81.1 to 8.81.7 to keep the OpenRewrite stack at a single coherent version.

Newer rewrite is more aggressive about removing imports it considers unused, so the JCFSortedMap/Set test fixtures' expected output drops the now-unused java.util.SortedMap and java.util.SortedSet imports.

Combines dependabot PRs #3794 and #3800, which fail individually because rewrite-java-17 8.81.x references rewrite-core APIs only present in matching rewrite-bom 8.81.x.