### PR TITLE
Bump error_prone_core to 2.49.0 and error-prone-contrib to 0.29.0 together.

### DIFF
--- a/liftwizard-maven-build/liftwizard-dependencies/pom.xml
+++ b/liftwizard-maven-build/liftwizard-dependencies/pom.xml
@@ -531,13 +531,13 @@
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>2.46.0</version>
+                <version>2.49.0</version>
             </dependency>
 
             <dependency>
                 <groupId>tech.picnic.error-prone-support</groupId>
                 <artifactId>error-prone-contrib</artifactId>
-                <version>0.28.0</version>
+                <version>0.29.0</version>
             </dependency>
 
             <dependency>

--- a/liftwizard-maven-build/liftwizard-profile-parent/pom.xml
+++ b/liftwizard-maven-build/liftwizard-profile-parent/pom.xml
@@ -868,12 +868,12 @@
                                 <path>
                                     <groupId>com.google.errorprone</groupId>
                                     <artifactId>error_prone_core</artifactId>
-                                    <version>2.46.0</version>
+                                    <version>2.49.0</version>
                                 </path>
                                 <path>
                                     <groupId>tech.picnic.error-prone-support</groupId>
                                     <artifactId>error-prone-contrib</artifactId>
-                                    <version>0.28.0</version>
+                                    <version>0.29.0</version>
                                 </path>
                                 <path>
                                     <groupId>tech.picnic.error-prone-support</groupId>


### PR DESCRIPTION
error-prone-contrib 0.29.0 is built against error-prone 2.49.0 and references com.google.errorprone.matchers.field.FieldMatchers, which only exists in 2.49.0; conversely, error-prone-contrib 0.28.0 references the old com.google.errorprone.matchers.FieldMatchers, which was relocated in 2.49.0. The two must move together.

This also unblocks the pending Dependabot bump of Guava 33.5.0 to 33.6.0, which collided with classes shaded inside error_prone_refaster 2.46.0.