### PR TITLE
Exclude Throwable arguments from Log4j 1 object-logging detection

### DIFF
--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLogging.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLogging.java
@@ -36,6 +36,10 @@ import org.openrewrite.marker.SearchResult;
  * to SLF4J (which only has {@code info(String)}) would either break compilation or silently
  * destroy structured logging if transformed to {@code info("{}", object)}.
  *
+ * <p>{@code Throwable} message arguments are excluded: calls like {@code LOGGER.error(exception)}
+ * are not structured object logging and migrate safely to SLF4J, which has a native
+ * {@code error(String, Throwable)} overload.
+ *
  * <p>This recipe is used as the basis for the {@link DoesNotUseLog4j1ObjectLogging} precondition,
  * which prevents the Log4j 1 to SLF4J migration from running on files that use this pattern.
  */
@@ -64,7 +68,9 @@ public final class UsesLog4j1ObjectLogging extends Recipe {
 		return (
 			"Finds Log4j 1.x logging calls where the message argument is not a String. "
 			+ "These calls pass an Object directly (e.g., `LOGGER.info(myObject)`) "
-			+ "which allows appenders to inspect the object's type for structured logging."
+			+ "which allows appenders to inspect the object's type for structured logging. "
+			+ "Throwable message arguments (e.g., `LOGGER.error(exception)`) are excluded "
+			+ "because they migrate safely to SLF4J."
 		);
 	}
 
@@ -84,7 +90,10 @@ public final class UsesLog4j1ObjectLogging extends Recipe {
 			for (MethodMatcher matcher : LOG_MATCHERS) {
 				if (matcher.matches(m)) {
 					Expression firstArg = m.getArguments().get(0);
-					if (!TypeUtils.isString(firstArg.getType())) {
+					if (
+						!TypeUtils.isString(firstArg.getType())
+						&& !TypeUtils.isAssignableTo("java.lang.Throwable", firstArg.getType())
+					) {
 						return SearchResult.found(m);
 					}
 					break;

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLoggingTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLoggingTest.java
@@ -34,6 +34,7 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 		    public void info(Object message) {}
 		    public void warn(Object message) {}
 		    public void error(Object message) {}
+		    public void error(Object message, Throwable t) {}
 		    public void fatal(Object message) {}
 		}
 		""";
@@ -207,6 +208,26 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 
 					    void test(String name) {
 					        LOGGER.info("Hello " + name);
+					    }
+					}
+					"""
+				)
+			);
+	}
+
+	@Test
+	void doesNotDetectThrowables() {
+		this.rewriteRun(
+				java(
+					"""
+					import org.apache.log4j.Logger;
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+
+					    void test(Exception exception) {
+					        LOGGER.error(exception);
+					        LOGGER.error(exception.getClass().getName(), exception);
 					    }
 					}
 					"""


### PR DESCRIPTION
## Summary

`UsesLog4j1ObjectLogging` flagged every logging call with a non-`String` first argument, so the `DoesNotUseLog4j1ObjectLogging` precondition skipped the whole file from the Log4j 1 → SLF4J migration. `Throwable` is a non-`String` `Object`, so `LOGGER.error(exception)` got flagged too.

But Throwable arguments are safe to migrate: SLF4J has a native `error(String, Throwable)` overload. They should not block migration.

Fix: also let the call through when the first argument is assignable to `java.lang.Throwable`. Genuine object logging (`LOGGER.info(myEvent)`) is still detected.

## Test plan

- [x] New test `UsesLog4j1ObjectLoggingTest#doesNotDetectThrowables` — `error(throwable)` and `error(string, throwable)` pass through undetected.
- [x] Existing `detects*` tests still flag real object arguments — no regression.