### PR TITLE
Add OpenRewrite recipes converting Eclipse Collections capturing lambdas to garbage-free *With method-reference form.

### DIFF
--- a/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/BooleanListLiteralVisitor.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/BooleanListLiteralVisitor.java
@@ -18,6 +18,7 @@ package io.liftwizard.model.reladomo.operation.compiler.literal.many;
 
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.BooleanListLiteralContext;
+import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.BooleanLiteralContext;
 import io.liftwizard.model.reladomo.operation.compiler.literal.AbstractLiteralVisitor;
 import io.liftwizard.model.reladomo.operation.compiler.literal.one.BooleanLiteralVisitor;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -40,7 +41,7 @@ public class BooleanListLiteralVisitor extends AbstractLiteralVisitor<ImmutableL
 	@Override
 	public ImmutableList<Boolean> visitBooleanListLiteral(BooleanListLiteralContext ctx) {
 		return ListAdapter.adapt(ctx.booleanLiteral())
-			.collect((each) -> each.accept(this.booleanLiteralVisitor))
+			.collectWith(BooleanLiteralContext::accept, this.booleanLiteralVisitor)
 			.toImmutable();
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/DoubleListLiteralVisitor.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/DoubleListLiteralVisitor.java
@@ -18,6 +18,7 @@ package io.liftwizard.model.reladomo.operation.compiler.literal.many;
 
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.FloatingPointListLiteralContext;
+import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.FloatingPointLiteralContext;
 import io.liftwizard.model.reladomo.operation.compiler.literal.AbstractLiteralVisitor;
 import io.liftwizard.model.reladomo.operation.compiler.literal.one.DoubleLiteralVisitor;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -40,7 +41,7 @@ public class DoubleListLiteralVisitor extends AbstractLiteralVisitor<ImmutableLi
 	@Override
 	public ImmutableList<Double> visitFloatingPointListLiteral(FloatingPointListLiteralContext ctx) {
 		return ListAdapter.adapt(ctx.floatingPointLiteral())
-			.collect((each) -> each.accept(this.doubleLiteralVisitor))
+			.collectWith(FloatingPointLiteralContext::accept, this.doubleLiteralVisitor)
 			.toImmutable();
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/FloatListLiteralVisitor.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/FloatListLiteralVisitor.java
@@ -18,6 +18,7 @@ package io.liftwizard.model.reladomo.operation.compiler.literal.many;
 
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.FloatingPointListLiteralContext;
+import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.FloatingPointLiteralContext;
 import io.liftwizard.model.reladomo.operation.compiler.literal.AbstractLiteralVisitor;
 import io.liftwizard.model.reladomo.operation.compiler.literal.one.FloatLiteralVisitor;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -40,7 +41,7 @@ public class FloatListLiteralVisitor extends AbstractLiteralVisitor<ImmutableLis
 	@Override
 	public ImmutableList<Float> visitFloatingPointListLiteral(FloatingPointListLiteralContext ctx) {
 		return ListAdapter.adapt(ctx.floatingPointLiteral())
-			.collect((each) -> each.accept(this.floatLiteralVisitor))
+			.collectWith(FloatingPointLiteralContext::accept, this.floatLiteralVisitor)
 			.toImmutable();
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/InstantListLiteralVisitor.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/InstantListLiteralVisitor.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.StringListLiteralContext;
+import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.StringLiteralContext;
 import io.liftwizard.model.reladomo.operation.compiler.literal.AbstractLiteralVisitor;
 import io.liftwizard.model.reladomo.operation.compiler.literal.one.InstantLiteralVisitor;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -42,7 +43,7 @@ public class InstantListLiteralVisitor extends AbstractLiteralVisitor<ImmutableL
 	@Override
 	public ImmutableList<Instant> visitStringListLiteral(StringListLiteralContext ctx) {
 		return ListAdapter.adapt(ctx.stringLiteral())
-			.collect((each) -> each.accept(this.instantLiteralVisitor))
+			.collectWith(StringLiteralContext::accept, this.instantLiteralVisitor)
 			.toImmutable();
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/IntegerListLiteralVisitor.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/IntegerListLiteralVisitor.java
@@ -18,6 +18,7 @@ package io.liftwizard.model.reladomo.operation.compiler.literal.many;
 
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.IntegerListLiteralContext;
+import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.IntegerLiteralContext;
 import io.liftwizard.model.reladomo.operation.compiler.literal.AbstractLiteralVisitor;
 import io.liftwizard.model.reladomo.operation.compiler.literal.one.IntegerLiteralVisitor;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -40,7 +41,7 @@ public class IntegerListLiteralVisitor extends AbstractLiteralVisitor<ImmutableL
 	@Override
 	public ImmutableList<Integer> visitIntegerListLiteral(IntegerListLiteralContext ctx) {
 		return ListAdapter.adapt(ctx.integerLiteral())
-			.collect((each) -> each.accept(this.integerLiteralVisitor))
+			.collectWith(IntegerLiteralContext::accept, this.integerLiteralVisitor)
 			.toImmutable();
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/LocalDateListLiteralVisitor.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/LocalDateListLiteralVisitor.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.StringListLiteralContext;
+import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.StringLiteralContext;
 import io.liftwizard.model.reladomo.operation.compiler.literal.AbstractLiteralVisitor;
 import io.liftwizard.model.reladomo.operation.compiler.literal.one.LocalDateLiteralVisitor;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -42,7 +43,7 @@ public class LocalDateListLiteralVisitor extends AbstractLiteralVisitor<Immutabl
 	@Override
 	public ImmutableList<LocalDate> visitStringListLiteral(StringListLiteralContext ctx) {
 		return ListAdapter.adapt(ctx.stringLiteral())
-			.collect((each) -> each.accept(this.localDateLiteralVisitor))
+			.collectWith(StringLiteralContext::accept, this.localDateLiteralVisitor)
 			.toImmutable();
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/LongListLiteralVisitor.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/LongListLiteralVisitor.java
@@ -18,6 +18,7 @@ package io.liftwizard.model.reladomo.operation.compiler.literal.many;
 
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.IntegerListLiteralContext;
+import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.IntegerLiteralContext;
 import io.liftwizard.model.reladomo.operation.compiler.literal.AbstractLiteralVisitor;
 import io.liftwizard.model.reladomo.operation.compiler.literal.one.LongLiteralVisitor;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -40,7 +41,7 @@ public class LongListLiteralVisitor extends AbstractLiteralVisitor<ImmutableList
 	@Override
 	public ImmutableList<Long> visitIntegerListLiteral(IntegerListLiteralContext ctx) {
 		return ListAdapter.adapt(ctx.integerLiteral())
-			.collect((each) -> each.accept(this.longLiteralVisitor))
+			.collectWith(IntegerLiteralContext::accept, this.longLiteralVisitor)
 			.toImmutable();
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/StringListLiteralVisitor.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-operation-compiler/src/main/java/io/liftwizard/model/reladomo/operation/compiler/literal/many/StringListLiteralVisitor.java
@@ -18,6 +18,7 @@ package io.liftwizard.model.reladomo.operation.compiler.literal.many;
 
 import com.gs.fw.common.mithra.finder.RelatedFinder;
 import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.StringListLiteralContext;
+import io.liftwizard.model.reladomo.operation.ReladomoOperationParser.StringLiteralContext;
 import io.liftwizard.model.reladomo.operation.compiler.literal.AbstractLiteralVisitor;
 import io.liftwizard.model.reladomo.operation.compiler.literal.one.StringLiteralVisitor;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -40,7 +41,7 @@ public class StringListLiteralVisitor extends AbstractLiteralVisitor<ImmutableLi
 	@Override
 	public ImmutableList<String> visitStringListLiteral(StringListLiteralContext ctx) {
 		return ListAdapter.adapt(ctx.stringLiteral())
-			.collect((each) -> each.accept(this.stringLiteralVisitor))
+			.collectWith(StringLiteralContext::accept, this.stringLiteralVisitor)
 			.toImmutable();
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-test-resource-writer/src/main/java/io/liftwizard/reladomo/test/resource/writer/ReladomoTestResourceGrid.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-test-resource-writer/src/main/java/io/liftwizard/reladomo/test/resource/writer/ReladomoTestResourceGrid.java
@@ -92,7 +92,7 @@ public class ReladomoTestResourceGrid {
 
 	private String getRowString(int index) {
 		return (
-			this.columns.collect((each) -> each.getPaddedValueString(index))
+			this.columns.collectWith(ReladomoTestResourceColumn::getPaddedValueString, index)
 				.makeString()
 				.stripTrailing()
 			+ "\n"

--- a/liftwizard-utility/liftwizard-rewrite/RECIPES.md
+++ b/liftwizard-utility/liftwizard-rewrite/RECIPES.md
@@ -254,6 +254,30 @@ Flip select() and reject() when the lambda contains a negation pattern:
 
 This eliminates double negation patterns and improves readability by using the more appropriate method for the predicate logic.
 
+### Garbage-Free Lambda Conversions
+
+#### ECGarbageFreeLambdas
+
+Convert capturing lambdas of the form `x -> x.foo(captured)` to the non-capturing `*With` method-reference form `Type::foo, captured`. The `*With` variants accept a `Predicate2`/`Function2`/`Procedure2` plus a captured parameter, so the call site uses a non-capturing method reference instead of a capturing lambda — the call site allocates no garbage per invocation. The captured value must not reference the lambda parameter. See Don Raab, [Fat-free lambdas in Java](https://donraab.medium.com/fat-free-lambdas-in-java-bf228da0613b) (Don's term for the same pattern).
+
+The composite recipe applies a single parameterized `GarbageFreeLambdaRecipe` to each transformable method, plus `ECDetectIfNoneToDetectWithIfNone` for the 3-arg `detectIfNone` overload:
+
+- `strings.select(s -> s.startsWith(prefix))` → `strings.selectWith(String::startsWith, prefix)`
+- `strings.select(s -> s.equals(target))` → `strings.selectWith(Object::equals, target)`
+- `strings.reject(s -> s.startsWith(prefix))` → `strings.rejectWith(String::startsWith, prefix)`
+- `strings.collect(s -> s.concat(suffix))` → `strings.collectWith(String::concat, suffix)`
+- `strings.detect(s -> s.startsWith(prefix))` → `strings.detectWith(String::startsWith, prefix)`
+- `strings.detectOptional(s -> s.startsWith(prefix))` → `strings.detectWithOptional(String::startsWith, prefix)`
+- `strings.detectIfNone(s -> s.startsWith(prefix), () -> "fallback")` → `strings.detectWithIfNone(String::startsWith, prefix, () -> "fallback")`
+- `strings.anySatisfy(s -> s.startsWith(prefix))` → `strings.anySatisfyWith(String::startsWith, prefix)`
+- `strings.allSatisfy(s -> s.startsWith(prefix))` → `strings.allSatisfyWith(String::startsWith, prefix)`
+- `strings.noneSatisfy(s -> s.startsWith(prefix))` → `strings.noneSatisfyWith(String::startsWith, prefix)`
+- `strings.count(s -> s.startsWith(prefix))` → `strings.countWith(String::startsWith, prefix)`
+- `strings.partition(s -> s.startsWith(prefix))` → `strings.partitionWith(String::startsWith, prefix)`
+- `strings.countBy(s -> s.concat(suffix))` → `strings.countByWith(String::concat, suffix)`
+- `builders.forEach(b -> b.append(text))` → `builders.forEachWith(StringBuilder::append, text)` (Eclipse Collections `forEach(Procedure)` overload)
+- `strings.removeIf(s -> s.startsWith(prefix))` → `strings.removeIfWith(String::startsWith, prefix)` (Eclipse Collections `MutableCollection.removeIf(Predicate)` overload)
+
 ### Method Reference Simplifications
 
 #### ECSimplifyMethodReferences

--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/ECDetectIfNoneToDetectWithIfNone.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/ECDetectIfNoneToDetectWithIfNone.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.eclipse.collections.bestpractices;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AddImport;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+/**
+ * Converts {@code richIterable.detectIfNone(x -> x.foo(captured), defaultFn)} to
+ * {@code richIterable.detectWithIfNone(Type::foo, captured, defaultFn)}.
+ *
+ * <p>The source method takes two arguments (predicate + {@code Function0}); the target takes three
+ * (predicate2 + captured + {@code Function0}). The captured value is spliced between the method reference
+ * and the {@code Function0}.
+ *
+ * <p>See {@link GarbageFreeLambdaRecipe} for the lambda shape rules.
+ */
+public class ECDetectIfNoneToDetectWithIfNone extends Recipe {
+
+	private static final MethodMatcher DETECT_IF_NONE_MATCHER = new MethodMatcher(
+		"org.eclipse.collections.api.RichIterable detectIfNone(org.eclipse.collections.api.block.predicate.Predicate, org.eclipse.collections.api.block.function.Function0)",
+		true
+	);
+
+	@Override
+	public String getDisplayName() {
+		return "`detectIfNone(x -> x.foo(captured), defaultFn)` → `detectWithIfNone(Type::foo, captured, defaultFn)`";
+	}
+
+	@Override
+	public String getDescription() {
+		return (
+			"Converts `richIterable.detectIfNone(x -> x.foo(captured), defaultFn)` to "
+			+ "`richIterable.detectWithIfNone(Type::foo, captured, defaultFn)` for Eclipse Collections types. "
+			+ "The captured value must not reference the lambda parameter."
+		);
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return Preconditions.check(
+			new UsesMethod<>(DETECT_IF_NONE_MATCHER),
+			new DetectIfNoneToDetectWithIfNoneVisitor()
+		);
+	}
+
+	private static final class DetectIfNoneToDetectWithIfNoneVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+		@Override
+		public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+			J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+
+			if (!DETECT_IF_NONE_MATCHER.matches(mi)) {
+				return mi;
+			}
+			if (mi.getArguments().size() != 2) {
+				return mi;
+			}
+			if (mi.getSelect() == null) {
+				return mi;
+			}
+
+			GarbageFreeLambdaVisitor.Result result = GarbageFreeLambdaVisitor.detect(mi.getArguments().get(0));
+			if (result == null) {
+				return mi;
+			}
+
+			Expression defaultFunction = mi.getArguments().get(1);
+
+			String templateSource =
+				"#{any()}.detectWithIfNone("
+				+ result.simpleName()
+				+ "::"
+				+ result.methodName()
+				+ ", #{any()}, #{any()})";
+
+			JavaTemplate template = JavaTemplate.builder(templateSource)
+				.imports(result.typeFqn())
+				.contextSensitive()
+				.javaParser(JavaParser.fromJavaVersion().classpath("eclipse-collections-api"))
+				.build();
+
+			if (!result.typeFqn().startsWith("java.lang.")) {
+				this.doAfterVisit(new AddImport<>(result.typeFqn(), null, false));
+			}
+
+			return template.apply(
+				this.getCursor(),
+				mi.getCoordinates().replace(),
+				mi.getSelect(),
+				result.capturedExpression(),
+				defaultFunction
+			);
+		}
+	}
+}

--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/GarbageFreeLambdaRecipe.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/GarbageFreeLambdaRecipe.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.eclipse.collections.bestpractices;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+
+/**
+ * Converts a single-arg Eclipse Collections method like {@code select(Predicate)} to its {@code *With}
+ * method-reference variant like {@code selectWith(Predicate2, P)}.
+ *
+ * <p>Parameterized via {@code matcherPattern} (full {@link MethodMatcher} pattern of the source method)
+ * and {@code targetMethodName} (the {@code *With} method to rewrite to). Intended to be instantiated from
+ * a YAML composite — see {@code META-INF/rewrite/eclipse-collections/bestpractices/garbage-free-lambdas.yml}.
+ */
+public class GarbageFreeLambdaRecipe extends Recipe {
+
+	@Option(
+		displayName = "Matcher pattern",
+		description = "The MethodMatcher pattern identifying the source method to rewrite.",
+		example = "org.eclipse.collections.api.RichIterable select(org.eclipse.collections.api.block.predicate.Predicate)"
+	)
+	private final String matcherPattern;
+
+	@Option(
+		displayName = "Target method name",
+		description = "The name of the *With method-reference variant to rewrite to.",
+		example = "selectWith"
+	)
+	private final String targetMethodName;
+
+	@JsonCreator
+	public GarbageFreeLambdaRecipe(
+		@JsonProperty("matcherPattern") String matcherPattern,
+		@JsonProperty("targetMethodName") String targetMethodName
+	) {
+		this.matcherPattern = matcherPattern;
+		this.targetMethodName = targetMethodName;
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "Convert Eclipse Collections capturing lambda to `*With` method reference";
+	}
+
+	@Override
+	public String getDescription() {
+		return (
+			"Rewrites a single-arg Eclipse Collections call like `richIterable.select(x -> x.foo(captured))` "
+			+ "to its non-capturing `*With` form `richIterable.selectWith(Type::foo, captured)`. "
+			+ "The captured value must not reference the lambda parameter."
+		);
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		MethodMatcher matcher = new MethodMatcher(this.matcherPattern, true);
+		return Preconditions.check(
+			new UsesMethod<>(matcher),
+			new GarbageFreeLambdaVisitor(matcher, this.targetMethodName)
+		);
+	}
+}

--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/GarbageFreeLambdaVisitor.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/GarbageFreeLambdaVisitor.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.eclipse.collections.bestpractices;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.AddImport;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.JavaType.FullyQualified;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
+
+/**
+ * Rewrites a matched single-arg Eclipse Collections call like {@code select(x -> x.foo(captured))} to its
+ * {@code *With} method-reference variant {@code selectWith(Type::foo, captured)}.
+ *
+ * <p>Two lambda shapes are accepted:
+ * <ul>
+ *   <li>Shape A — instance method on the lambda parameter: {@code x -> x.foo(captured)} becomes
+ *       {@code Type::foo, captured}.</li>
+ *   <li>Shape B — equality on the lambda parameter: {@code x -> x.equals(captured)} becomes
+ *       {@code Object::equals, captured}.</li>
+ * </ul>
+ *
+ * <p>The static {@link #detect} method is reused by {@link ECDetectIfNoneToDetectWithIfNone} for the
+ * structurally different 3-arg {@code detectIfNone} overload.
+ */
+final class GarbageFreeLambdaVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+	private final MethodMatcher matcher;
+	private final String targetMethodName;
+
+	GarbageFreeLambdaVisitor(MethodMatcher matcher, String targetMethodName) {
+		this.matcher = matcher;
+		this.targetMethodName = targetMethodName;
+	}
+
+	@Override
+	public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+		J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+
+		if (!this.matcher.matches(mi)) {
+			return mi;
+		}
+		if (mi.getArguments().size() != 1) {
+			return mi;
+		}
+		if (mi.getSelect() == null) {
+			return mi;
+		}
+
+		Result result = detect(mi.getArguments().get(0));
+		if (result == null) {
+			return mi;
+		}
+
+		String templateSource =
+			"#{any()}."
+			+ this.targetMethodName
+			+ "("
+			+ result.simpleName()
+			+ "::"
+			+ result.methodName()
+			+ ", #{any()})";
+
+		JavaTemplate template = JavaTemplate.builder(templateSource)
+			.imports(result.typeFqn())
+			.contextSensitive()
+			.javaParser(JavaParser.fromJavaVersion().classpath("eclipse-collections-api"))
+			.build();
+
+		if (!result.typeFqn().startsWith("java.lang.")) {
+			this.doAfterVisit(new AddImport<>(result.typeFqn(), null, false));
+		}
+
+		return template.apply(
+			this.getCursor(),
+			mi.getCoordinates().replace(),
+			mi.getSelect(),
+			result.capturedExpression()
+		);
+	}
+
+	static Result detect(Expression argument) {
+		if (!(argument instanceof J.Lambda lambda)) {
+			return null;
+		}
+
+		if (lambda.getParameters().getParameters().size() != 1) {
+			return null;
+		}
+
+		J firstParameter = lambda.getParameters().getParameters().get(0);
+		if (!(firstParameter instanceof J.VariableDeclarations varDecls)) {
+			return null;
+		}
+		if (varDecls.getVariables().size() != 1) {
+			return null;
+		}
+		J.VariableDeclarations.NamedVariable namedVariable = varDecls.getVariables().get(0);
+		JavaType paramType = namedVariable.getType();
+		if (paramType == null) {
+			return null;
+		}
+
+		J body = lambda.getBody();
+		if (body instanceof J.Block block) {
+			if (block.getStatements().size() != 1) {
+				return null;
+			}
+			Statement onlyStatement = block.getStatements().get(0);
+			if (!(onlyStatement instanceof J.Return returnStatement)) {
+				return null;
+			}
+			Expression returned = returnStatement.getExpression();
+			if (returned == null) {
+				return null;
+			}
+			body = returned;
+		}
+
+		if (!(body instanceof J.MethodInvocation innerCall)) {
+			return null;
+		}
+
+		Expression select = innerCall.getSelect();
+		if (!(select instanceof J.Identifier selectIdentifier)) {
+			return null;
+		}
+		String paramName = namedVariable.getSimpleName();
+		if (!selectIdentifier.getSimpleName().equals(paramName)) {
+			return null;
+		}
+
+		if (innerCall.getArguments().size() != 1) {
+			return null;
+		}
+		Expression capturedExpression = innerCall.getArguments().get(0);
+		if (capturedExpression instanceof J.Empty) {
+			return null;
+		}
+
+		if (referencesParameter(capturedExpression, paramName)) {
+			return null;
+		}
+
+		FullyQualified paramFqn = TypeUtils.asFullyQualified(paramType);
+		if (paramFqn == null) {
+			return null;
+		}
+
+		String methodName = innerCall.getSimpleName();
+
+		if (methodName.equals("equals")) {
+			return new Result("java.lang.Object", "Object", "equals", capturedExpression);
+		}
+
+		String className = paramFqn.getClassName();
+		String leafName = className.substring(className.lastIndexOf('.') + 1);
+		return new Result(paramFqn.getFullyQualifiedName(), leafName, methodName, capturedExpression);
+	}
+
+	private static boolean referencesParameter(Expression expression, String paramName) {
+		ReferenceChecker checker = new ReferenceChecker(paramName);
+		checker.visit(expression, null);
+		return checker.found;
+	}
+
+	private static final class ReferenceChecker extends JavaIsoVisitor<Object> {
+
+		private final String paramName;
+		private boolean found;
+
+		ReferenceChecker(String paramName) {
+			this.paramName = paramName;
+		}
+
+		@Override
+		public J.Identifier visitIdentifier(J.Identifier identifier, Object ignored) {
+			if (!this.found && identifier.getSimpleName().equals(this.paramName)) {
+				this.found = true;
+			}
+			return identifier;
+		}
+	}
+
+	record Result(String typeFqn, String simpleName, String methodName, Expression capturedExpression) {}
+}

--- a/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/eclipse-collections-best-practices.yml
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/eclipse-collections-best-practices.yml
@@ -24,6 +24,7 @@ recipeList:
     - io.liftwizard.rewrite.eclipse.collections.bestpractices.ECSimplifyNegatedEmptyChecks
     - io.liftwizard.rewrite.eclipse.collections.bestpractices.ECSimplifyNegatedSatisfiesRecipes
     - io.liftwizard.rewrite.eclipse.collections.bestpractices.ECSimplifyNegatedSelectReject
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.ECGarbageFreeLambdas
     - io.liftwizard.rewrite.eclipse.collections.bestpractices.ECSimplifyMethodReferences
     - io.liftwizard.rewrite.eclipse.collections.bestpractices.ECAnySatisfyPredicatesNotToNoneSatisfyRecipes
     - io.liftwizard.rewrite.eclipse.collections.bestpractices.ECNoneSatisfyPredicatesNotToAnySatisfyRecipes

--- a/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/eclipse-collections/bestpractices/garbage-free-lambdas.yml
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/eclipse-collections/bestpractices/garbage-free-lambdas.yml
@@ -1,0 +1,66 @@
+#
+# Copyright 2026 Craig Motlin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.liftwizard.rewrite.eclipse.collections.bestpractices.ECGarbageFreeLambdas
+displayName: Eclipse Collections garbage-free lambdas
+description: >-
+    Convert Eclipse Collections capturing lambdas like `list.select(s -> s.startsWith(prefix))` to the
+    non-capturing `*With` form `list.selectWith(String::startsWith, prefix)`, allowing the JIT to cache a
+    single function instance per call site instead of allocating one per invocation. Inspired by Don Raab,
+    [Fat-free lambdas in Java](https://donraab.medium.com/fat-free-lambdas-in-java-bf228da0613b).
+recipeList:
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable select(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: selectWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable reject(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: rejectWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable collect(org.eclipse.collections.api.block.function.Function)
+          targetMethodName: collectWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable detect(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: detectWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable detectOptional(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: detectWithOptional
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.ECDetectIfNoneToDetectWithIfNone
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable anySatisfy(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: anySatisfyWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable allSatisfy(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: allSatisfyWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable noneSatisfy(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: noneSatisfyWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable count(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: countWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable partition(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: partitionWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable countBy(org.eclipse.collections.api.block.function.Function)
+          targetMethodName: countByWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.RichIterable forEach(org.eclipse.collections.api.block.procedure.Procedure)
+          targetMethodName: forEachWith
+    - io.liftwizard.rewrite.eclipse.collections.bestpractices.GarbageFreeLambdaRecipe:
+          matcherPattern: org.eclipse.collections.api.collection.MutableCollection removeIf(org.eclipse.collections.api.block.predicate.Predicate)
+          targetMethodName: removeIfWith

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/ECGarbageFreeLambdasTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/eclipse/collections/bestpractices/ECGarbageFreeLambdasTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.eclipse.collections.bestpractices;
+
+import io.liftwizard.rewrite.eclipse.collections.AbstractEclipseCollectionsTest;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ECGarbageFreeLambdasTest extends AbstractEclipseCollectionsTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		super.defaults(spec);
+		spec.recipeFromResources("io.liftwizard.rewrite.eclipse.collections.bestpractices.ECGarbageFreeLambdas");
+	}
+
+	@Test
+	@DocumentExample
+	void replacePatterns() {
+		this.rewriteRun(
+				java(
+					"""
+					import java.util.Map;
+					import java.util.Map.Entry;
+					import org.eclipse.collections.api.RichIterable;
+					import org.eclipse.collections.api.list.MutableList;
+
+					class Test {
+					    MutableList<String> strings;
+					    MutableList<StringBuilder> builders;
+					    MutableList<Entry<String, Integer>> entries;
+					    RichIterable<String> richIterable;
+					    String prefix;
+					    String target;
+					    String suffix;
+					    String text;
+					    Integer value;
+
+					    void all() {
+					        strings.select(s -> s.startsWith(prefix));
+					        strings.select(s -> s.equals(target));
+					        strings.select(s -> { return s.startsWith(prefix); });
+					        richIterable.select(s -> s.startsWith(prefix));
+					        strings.reject(s -> s.startsWith(prefix));
+					        strings.collect(s -> s.concat(suffix));
+					        strings.detect(s -> s.startsWith(prefix));
+					        strings.detectOptional(s -> s.startsWith(prefix));
+					        strings.detectIfNone(s -> s.startsWith(prefix), () -> "fallback");
+					        strings.anySatisfy(s -> s.startsWith(prefix));
+					        strings.allSatisfy(s -> s.startsWith(prefix));
+					        strings.noneSatisfy(s -> s.startsWith(prefix));
+					        strings.count(s -> s.startsWith(prefix));
+					        strings.partition(s -> s.startsWith(prefix));
+					        strings.countBy(s -> s.concat(suffix));
+					        builders.forEach(b -> b.append(text));
+					        strings.removeIf(s -> s.startsWith(prefix));
+					        entries.anySatisfy(e -> e.equals(value));
+					        entries.forEach(e -> e.setValue(value));
+					    }
+					}
+					""",
+					"""
+					import java.util.Map;
+					import java.util.Map.Entry;
+					import org.eclipse.collections.api.RichIterable;
+					import org.eclipse.collections.api.list.MutableList;
+
+					class Test {
+					    MutableList<String> strings;
+					    MutableList<StringBuilder> builders;
+					    MutableList<Entry<String, Integer>> entries;
+					    RichIterable<String> richIterable;
+					    String prefix;
+					    String target;
+					    String suffix;
+					    String text;
+					    Integer value;
+
+					    void all() {
+					        strings.selectWith(String::startsWith, prefix);
+					        strings.selectWith(Object::equals, target);
+					        strings.selectWith(String::startsWith, prefix);
+					        richIterable.selectWith(String::startsWith, prefix);
+					        strings.rejectWith(String::startsWith, prefix);
+					        strings.collectWith(String::concat, suffix);
+					        strings.detectWith(String::startsWith, prefix);
+					        strings.detectWithOptional(String::startsWith, prefix);
+					        strings.detectWithIfNone(String::startsWith, prefix, () -> "fallback");
+					        strings.anySatisfyWith(String::startsWith, prefix);
+					        strings.allSatisfyWith(String::startsWith, prefix);
+					        strings.noneSatisfyWith(String::startsWith, prefix);
+					        strings.countWith(String::startsWith, prefix);
+					        strings.partitionWith(String::startsWith, prefix);
+					        strings.countByWith(String::concat, suffix);
+					        builders.forEachWith(StringBuilder::append, text);
+					        strings.removeIfWith(String::startsWith, prefix);
+					        entries.anySatisfyWith(Object::equals, value);
+					        entries.forEachWith(Entry::setValue, value);
+					    }
+					}
+					"""
+				)
+			);
+	}
+
+	@Test
+	void doNotReplaceInvalidPatterns() {
+		this.rewriteRun(
+				java(
+					"""
+					import org.eclipse.collections.api.block.function.Function;
+					import org.eclipse.collections.api.block.predicate.Predicate;
+					import org.eclipse.collections.api.list.MutableList;
+
+					class Test {
+					    MutableList<String> strings;
+					    MutableList<StringBuilder> builders;
+					    Predicate<String> predicate;
+					    Function<String, String> fn;
+					    String prefix;
+
+					    void all() {
+					        strings.select(s -> s.startsWith(s));
+					        strings.select(s -> s.isEmpty());
+					        strings.select(s -> s.trim().startsWith(prefix));
+					        strings.select(String::isEmpty);
+					        strings.select(predicate);
+					        strings.select(s -> s.regionMatches(0, prefix, 0, 1));
+					        strings.collect(fn);
+					        strings.collect(String::trim);
+					        strings.detectIfNone(s -> s.startsWith(s), () -> "");
+					        strings.detectIfNone(String::isEmpty, () -> "");
+					        builders.forEach(b -> b.append(b.toString()));
+					        builders.forEach(StringBuilder::reverse);
+					    }
+					}
+					"""
+				)
+			);
+	}
+}


### PR DESCRIPTION
Inspired by @donraab's [Fat-free lambdas in Java](https://donraab.medium.com/fat-free-lambdas-in-java-bf228da0613b), these OpenRewrite recipes mechanically convert capturing lambdas like `list.select(s -> s.startsWith(prefix))` into the non-capturing `list.selectWith(String::startsWith, prefix)` form, so the JIT can cache a single function instance per call site instead of allocating one per invocation.