### PR TITLE
Skip Log4j 1 fatal logging in the SLF4J migration recipe

### DIFF
--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/DoesNotUseLog4jFatal.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/DoesNotUseLog4jFatal.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.logging;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+/**
+ * Precondition recipe that matches files which do <em>not</em> use Log4j 1.x {@code fatal} logging.
+ *
+ * <p>This is the negation of {@link UsesLog4jFatal}. It is intended to be used as a YAML
+ * {@code preconditions} entry so that a composite migration recipe (e.g., Log4j 1 to SLF4J)
+ * skips files that log at the {@code FATAL} level, which has no SLF4J equivalent.
+ */
+public final class DoesNotUseLog4jFatal extends Recipe {
+
+	@Override
+	public String getDisplayName() {
+		return "Does not use Log4j 1.x fatal logging";
+	}
+
+	@Override
+	public String getDescription() {
+		return (
+			"Precondition that matches source files which do not use the Log4j 1.x `fatal` level "
+			+ "(e.g., `LOGGER.fatal(message)`). Files that use fatal logging are excluded, preventing "
+			+ "migration recipes from downgrading FATAL to ERROR, which has no equivalent in SLF4J."
+		);
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return Preconditions.not(new UsesLog4jFatal.Log4jFatalVisitor());
+	}
+}

--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4jFatal.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4jFatal.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.logging;
+
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * Search recipe that finds Log4j 1.x {@code fatal} logging calls.
+ *
+ * <p>Log4j 1's {@code Category.fatal(Object)} logs at the {@code FATAL} level, which has no
+ * equivalent in SLF4J (whose highest level is {@code ERROR}). Migrating such calls to SLF4J
+ * would either break compilation or silently downgrade them to {@code error}, losing the
+ * {@code FATAL} severity.
+ *
+ * <p>This recipe is used as the basis for the {@link DoesNotUseLog4jFatal} precondition, which
+ * prevents the Log4j 1 to SLF4J migration from running on files that use this pattern.
+ */
+public final class UsesLog4jFatal extends Recipe {
+
+	private static final List<MethodMatcher> LOG_MATCHERS = List.of(
+		new MethodMatcher("org.apache.log4j.Logger fatal(..)", true),
+		new MethodMatcher("org.apache.log4j.Category fatal(..)", true)
+	);
+
+	@Override
+	public String getDisplayName() {
+		return "Find Log4j 1.x fatal logging calls";
+	}
+
+	@Override
+	public String getDescription() {
+		return (
+			"Finds Log4j 1.x logging calls that use the `fatal` level (e.g., `LOGGER.fatal(message)`). "
+			+ "SLF4J has no `fatal` level, so these calls cannot be migrated automatically without "
+			+ "losing the FATAL severity."
+		);
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return new Log4jFatalVisitor();
+	}
+
+	static final class Log4jFatalVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+		@Override
+		public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+			J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+			for (MethodMatcher matcher : LOG_MATCHERS) {
+				if (matcher.matches(m)) {
+					return SearchResult.found(m);
+				}
+			}
+			return m;
+		}
+	}
+}

--- a/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/logging/log4j-1-to-slf4j.yml
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/logging/log4j-1-to-slf4j.yml
@@ -22,10 +22,13 @@ description: >-
     Transforms usages of Log4j 1.x to leveraging SLF4J 1.x directly.
     Unlike the upstream recipe, this version skips files that pass non-String
     Objects to Log4j 1 logging methods (e.g., LOGGER.info(myObject)),
-    preserving structured logging capabilities. Files with object logging
-    remain on Log4j 1 and must be migrated manually.
+    preserving structured logging capabilities. It also skips files that log at
+    the FATAL level (e.g., LOGGER.fatal(message)), which has no SLF4J equivalent.
+    Files with object logging or fatal logging remain on Log4j 1 and must be
+    migrated manually.
 preconditions:
     - io.liftwizard.rewrite.logging.DoesNotUseLog4j1ObjectLogging
+    - io.liftwizard.rewrite.logging.DoesNotUseLog4jFatal
 recipeList:
     - org.openrewrite.java.ChangeType:
           oldFullyQualifiedTypeName: org.apache.log4j.MDC

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4jFatalTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4jFatalTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.logging;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class UsesLog4jFatalTest implements RewriteTest {
+
+	private static final String LOG4J_CATEGORY_STUB = """
+		package org.apache.log4j;
+		public class Category {
+		    public static Logger getLogger(Class clazz) { return null; }
+		    public void debug(Object message) {}
+		    public void info(Object message) {}
+		    public void warn(Object message) {}
+		    public void error(Object message) {}
+		    public void fatal(Object message) {}
+		    public void fatal(Object message, Throwable t) {}
+		}
+		""";
+
+	private static final String LOG4J_LOGGER_STUB = """
+		package org.apache.log4j;
+		public class Logger extends Category {
+		    public static Logger getLogger(Class clazz) { return null; }
+		}
+		""";
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec
+			.recipe(new UsesLog4jFatal())
+			.parser(JavaParser.fromJavaVersion().dependsOn(LOG4J_CATEGORY_STUB, LOG4J_LOGGER_STUB));
+	}
+
+	@DocumentExample
+	@Test
+	void replacePatterns() {
+		this.rewriteRun(
+				java(
+					"""
+					import org.apache.log4j.Logger;
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+
+					    void detectsStringLiteral() {
+					        LOGGER.fatal("Simple message");
+					    }
+
+					    void detectsStringVariable(String message) {
+					        LOGGER.fatal(message);
+					    }
+
+					    void detectsObjectArgument(Object myObject) {
+					        LOGGER.fatal(myObject);
+					    }
+
+					    void detectsThrowableArgument(Exception exception) {
+					        LOGGER.fatal("Failure", exception);
+					    }
+					}
+					""",
+					"""
+					import org.apache.log4j.Logger;
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+
+					    void detectsStringLiteral() {
+					        /*~~>*/LOGGER.fatal("Simple message");
+					    }
+
+					    void detectsStringVariable(String message) {
+					        /*~~>*/LOGGER.fatal(message);
+					    }
+
+					    void detectsObjectArgument(Object myObject) {
+					        /*~~>*/LOGGER.fatal(myObject);
+					    }
+
+					    void detectsThrowableArgument(Exception exception) {
+					        /*~~>*/LOGGER.fatal("Failure", exception);
+					    }
+					}
+					"""
+				)
+			);
+	}
+
+	@Test
+	void doNotReplaceInvalidPatterns() {
+		this.rewriteRun(
+				java(
+					"""
+					import org.apache.log4j.Logger;
+
+					class CustomLogger {
+					    void fatal(String message) {}
+					}
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+					    private final CustomLogger custom = new CustomLogger();
+
+					    void doesNotDetectOtherLevels(String message) {
+					        LOGGER.debug(message);
+					        LOGGER.info(message);
+					        LOGGER.warn(message);
+					        LOGGER.error(message);
+					    }
+
+					    void doesNotDetectUnrelatedFatal(String message) {
+					        custom.fatal(message);
+					    }
+					}
+					"""
+				)
+			);
+	}
+}


### PR DESCRIPTION
## What

The `io.liftwizard.rewrite.logging.Log4j1ToSlf4j1` recipe migrates Log4j 1.x usages
to SLF4J 1.x. SLF4J has no `FATAL` level, so `org.apache.log4j.Logger`/`Category`
`fatal(..)` calls cannot be migrated automatically without silently downgrading them
to `error`, losing the FATAL severity. This adds a precondition that leaves files
using `fatal` on Log4j 1 to be migrated manually.

## How

Mirrors the existing `UsesLog4j1ObjectLogging` / `DoesNotUseLog4j1ObjectLogging`
precondition pair:

- **`UsesLog4jFatal`** — a search `Recipe` with a `JavaIsoVisitor` that
  `MethodMatcher`-matches `org.apache.log4j.Logger fatal(..)` and
  `org.apache.log4j.Category fatal(..)`, marking every match. Unlike the
  object-logging recipe it does no argument-type filtering, since `fatal` has no
  SLF4J equivalent at all.
- **`DoesNotUseLog4jFatal`** — a precondition `Recipe` returning
  `Preconditions.not(new UsesLog4jFatal.Log4jFatalVisitor())`.
- **`log4j-1-to-slf4j.yml`** — adds `DoesNotUseLog4jFatal` to the `preconditions:`
  list (AND-ed with the existing object-logging precondition) and updates the
  description.

A stock `UsesMethod` precondition was considered instead of the hand-written visitor,
but the explicit `JavaIsoVisitor` keeps the new pair symmetric with its sibling.

## Testing

- [x] `mvn test -pl liftwizard-utility/liftwizard-rewrite -am` — full module passes,
  including the new `UsesLog4jFatalTest` (positive `replacePatterns`, negative
  `doNotReplaceInvalidPatterns`) and the existing logging tests.
