### PR TITLE
Upgrade just to 1.52.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,6 +1,6 @@
 [tools]
 java = "temurin-21.0.10+7.0.LTS"
-just = "1.49.0"
+just = "1.52.0"
 maven = "3.9.14"
 mvnd = "1.0.5"
 node = "24.14.1"


### PR DESCRIPTION
Bumps the pinned `just` version to 1.52.0 in `.mise/config.toml` to match the project-template baseline.