### PR TITLE
feat(recipes): add trace level matcher to UsesLog4j1ObjectLogging

### DIFF
--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLogging.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLogging.java
@@ -51,6 +51,7 @@ public final class UsesLog4j1ObjectLogging extends Recipe {
 		new MethodMatcher("org.apache.log4j.Category warn(..)", true),
 		new MethodMatcher("org.apache.log4j.Category error(..)", true),
 		new MethodMatcher("org.apache.log4j.Category fatal(..)", true),
+		new MethodMatcher("org.apache.log4j.Logger trace(..)", true),
 		new MethodMatcher("org.apache.log4j.Logger debug(..)", true),
 		new MethodMatcher("org.apache.log4j.Logger info(..)", true),
 		new MethodMatcher("org.apache.log4j.Logger warn(..)", true),

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLoggingTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLoggingTest.java
@@ -43,6 +43,7 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 		package org.apache.log4j;
 		public class Logger extends Category {
 		    public static Logger getLogger(Class clazz) { return null; }
+		    public void trace(Object message) {}
 		}
 		""";
 
@@ -77,6 +78,7 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 					    }
 
 					    void detectsAcrossLogLevels(Object obj) {
+					        LOGGER.trace(obj);
 					        LOGGER.debug(obj);
 					        LOGGER.warn(obj);
 					        LOGGER.error(obj);
@@ -103,6 +105,7 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 					    }
 
 					    void detectsAcrossLogLevels(Object obj) {
+					        /*~~>*/LOGGER.trace(obj);
 					        /*~~>*/LOGGER.debug(obj);
 					        /*~~>*/LOGGER.warn(obj);
 					        /*~~>*/LOGGER.error(obj);
@@ -156,6 +159,7 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 			package org.apache.log4j;
 			public class Logger {
 			    public static Logger getLogger(Class clazz) { return null; }
+			    public void trace(Object message) {}
 			    public void debug(Object message) {}
 			    public void info(Object message) {}
 			    public void warn(Object message) {}


### PR DESCRIPTION
Added `Logger trace(..)` to `LOG_MATCHERS` in `UsesLog4j1ObjectLogging`, covering Log4j 1's `trace` method which exists only on `Logger` (not `Category`). Tests updated accordingly.