### PR TITLE
Detect Log4j 1 fatal method references and the Level.FATAL constant

### DIFF
--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/DoesNotUseLog4jFatal.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/DoesNotUseLog4jFatal.java
@@ -46,6 +46,6 @@ public final class DoesNotUseLog4jFatal extends Recipe {
 
 	@Override
 	public TreeVisitor<?, ExecutionContext> getVisitor() {
-		return Preconditions.not(new UsesLog4jFatal.Log4jFatalVisitor());
+		return Preconditions.not(UsesLog4jFatal.fatalUsage());
 	}
 }

--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4jFatal.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4jFatal.java
@@ -16,64 +16,115 @@
 
 package io.liftwizard.rewrite.logging;
 
-import java.util.List;
-
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.SearchResult;
 
 /**
- * Search recipe that finds Log4j 1.x {@code fatal} logging calls.
+ * Search recipe that finds Log4j 1.x {@code fatal} logging usage.
  *
  * <p>Log4j 1's {@code Category.fatal(Object)} logs at the {@code FATAL} level, which has no
- * equivalent in SLF4J (whose highest level is {@code ERROR}). Migrating such calls to SLF4J
- * would either break compilation or silently downgrade them to {@code error}, losing the
+ * equivalent in SLF4J (whose highest level is {@code ERROR}). Migrating such usage to SLF4J
+ * would either break compilation or silently downgrade it to {@code error}, losing the
  * {@code FATAL} severity.
  *
- * <p>This recipe is used as the basis for the {@link DoesNotUseLog4jFatal} precondition, which
- * prevents the Log4j 1 to SLF4J migration from running on files that use this pattern.
+ * <p>Detection covers all the ways FATAL reaches Log4j 1:
+ * <ul>
+ *     <li>{@code fatal(..)} method <em>invocations</em> ({@code LOGGER.fatal(message)});</li>
+ *     <li>{@code fatal} method <em>references</em> ({@code LOGGER::fatal});</li>
+ *     <li>the {@code Level.FATAL} / {@code Priority.FATAL} constant (e.g.
+ *         {@code LOGGER.log(Level.FATAL, message)} or any bare reference to the constant).</li>
+ * </ul>
+ *
+ * <p>Method invocations and references are found with {@link UsesMethod}, which matches every call
+ * form via the compilation unit's resolved method types. The {@code FATAL} constant is a field, not
+ * a method, so it is found with a dedicated field-access visitor.
+ *
+ * <p>This recipe is the basis for the {@link DoesNotUseLog4jFatal} precondition, which prevents the
+ * Log4j 1 to SLF4J migration from running on files that use this pattern.
  */
 public final class UsesLog4jFatal extends Recipe {
 
-	private static final List<MethodMatcher> LOG_MATCHERS = List.of(
-		new MethodMatcher("org.apache.log4j.Logger fatal(..)", true),
-		new MethodMatcher("org.apache.log4j.Category fatal(..)", true)
-	);
+	private static final String LOG4J_PRIORITY = "org.apache.log4j.Priority";
+	private static final String FATAL_FIELD_NAME = "FATAL";
 
 	@Override
 	public String getDisplayName() {
-		return "Find Log4j 1.x fatal logging calls";
+		return "Find Log4j 1.x fatal logging usage";
 	}
 
 	@Override
 	public String getDescription() {
 		return (
-			"Finds Log4j 1.x logging calls that use the `fatal` level (e.g., `LOGGER.fatal(message)`). "
-			+ "SLF4J has no `fatal` level, so these calls cannot be migrated automatically without "
-			+ "losing the FATAL severity."
+			"Finds Log4j 1.x logging that uses the `fatal` level, including `fatal(..)` method "
+			+ "invocations (e.g., `LOGGER.fatal(message)`), `fatal` method references "
+			+ "(e.g., `LOGGER::fatal`), and the `Level.FATAL`/`Priority.FATAL` constant "
+			+ "(e.g., `LOGGER.log(Level.FATAL, message)`). SLF4J has no `fatal` level, so these "
+			+ "cannot be migrated automatically without losing the FATAL severity."
 		);
 	}
 
 	@Override
 	public TreeVisitor<?, ExecutionContext> getVisitor() {
-		return new Log4jFatalVisitor();
+		return fatalUsage();
 	}
 
-	static final class Log4jFatalVisitor extends JavaIsoVisitor<ExecutionContext> {
+	/**
+	 * Builds the visitor that flags any Log4j 1.x FATAL usage. Shared with {@link DoesNotUseLog4jFatal}
+	 * so the precondition stays in sync with this recipe's detection.
+	 */
+	static TreeVisitor<?, ExecutionContext> fatalUsage() {
+		// Logger extends Category and inherits fatal(..), so matching the declaring type covers both.
+		return Preconditions.or(
+			new UsesMethod<>("org.apache.log4j.Category fatal(..)", true),
+			new LevelFatalConstantVisitor()
+		);
+	}
+
+	/**
+	 * Flags references to the {@code FATAL} constant declared on {@code org.apache.log4j.Priority}
+	 * (and its subclass {@code Level}), whether qualified ({@code Level.FATAL}) or statically imported
+	 * (bare {@code FATAL}).
+	 */
+	static final class LevelFatalConstantVisitor extends JavaIsoVisitor<ExecutionContext> {
 
 		@Override
-		public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-			J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
-			for (MethodMatcher matcher : LOG_MATCHERS) {
-				if (matcher.matches(m)) {
-					return SearchResult.found(m);
-				}
+		public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
+			J.FieldAccess fa = super.visitFieldAccess(fieldAccess, ctx);
+			if (isFatalConstant(fa.getSimpleName(), fa.getTarget().getType())) {
+				return SearchResult.found(fa);
 			}
-			return m;
+			return fa;
+		}
+
+		@Override
+		public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
+			J.Identifier id = super.visitIdentifier(identifier, ctx);
+			// Cheap name check first: visitIdentifier runs for every identifier in the file.
+			if (!FATAL_FIELD_NAME.equals(id.getSimpleName()) || isFieldAccessName(this.getCursor())) {
+				return id;
+			}
+			JavaType.Variable fieldType = id.getFieldType();
+			if (fieldType != null && TypeUtils.isAssignableTo(LOG4J_PRIORITY, fieldType.getOwner())) {
+				return SearchResult.found(id);
+			}
+			return id;
+		}
+
+		private static boolean isFatalConstant(String simpleName, JavaType ownerType) {
+			return FATAL_FIELD_NAME.equals(simpleName) && TypeUtils.isAssignableTo(LOG4J_PRIORITY, ownerType);
+		}
+
+		private static boolean isFieldAccessName(Cursor cursor) {
+			return cursor.getParentTreeCursor().getValue() instanceof J.FieldAccess;
 		}
 	}
 }

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4jFatalTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4jFatalTest.java
@@ -36,6 +36,8 @@ class UsesLog4jFatalTest implements RewriteTest {
 		    public void error(Object message) {}
 		    public void fatal(Object message) {}
 		    public void fatal(Object message, Throwable t) {}
+		    public void log(Priority priority, Object message) {}
+		    public void log(Priority priority, Object message, Throwable t) {}
 		}
 		""";
 
@@ -46,61 +48,119 @@ class UsesLog4jFatalTest implements RewriteTest {
 		}
 		""";
 
+	private static final String LOG4J_PRIORITY_STUB = """
+		package org.apache.log4j;
+		public class Priority {
+		    public static final Priority FATAL = null;
+		    public static final Priority ERROR = null;
+		}
+		""";
+
+	private static final String LOG4J_LEVEL_STUB = """
+		package org.apache.log4j;
+		public class Level extends Priority {
+		    public static final Level FATAL = null;
+		    public static final Level ERROR = null;
+		    public static final Level DEBUG = null;
+		}
+		""";
+
 	@Override
 	public void defaults(RecipeSpec spec) {
 		spec
 			.recipe(new UsesLog4jFatal())
-			.parser(JavaParser.fromJavaVersion().dependsOn(LOG4J_CATEGORY_STUB, LOG4J_LOGGER_STUB));
+			.parser(
+				JavaParser.fromJavaVersion().dependsOn(
+					LOG4J_CATEGORY_STUB,
+					LOG4J_LOGGER_STUB,
+					LOG4J_PRIORITY_STUB,
+					LOG4J_LEVEL_STUB
+				)
+			);
 	}
 
 	@DocumentExample
 	@Test
 	void replacePatterns() {
 		this.rewriteRun(
+				// fatal method usage marks the compilation unit (UsesMethod), while the Level.FATAL
+				// constant is marked in place; the Preconditions.or composition surfaces these across
+				// two cycles when both appear in one file.
+				(spec) -> spec.expectedCyclesThatMakeChanges(2),
 				java(
 					"""
+					import org.apache.log4j.Level;
 					import org.apache.log4j.Logger;
+
+					import java.util.Optional;
 
 					class Test {
 					    private static final Logger LOGGER = Logger.getLogger(Test.class);
 
-					    void detectsStringLiteral() {
+					    void fatalStringLiteral() {
 					        LOGGER.fatal("Simple message");
 					    }
 
-					    void detectsStringVariable(String message) {
+					    void fatalStringVariable(String message) {
 					        LOGGER.fatal(message);
 					    }
 
-					    void detectsObjectArgument(Object myObject) {
+					    void fatalObjectArgument(Object myObject) {
 					        LOGGER.fatal(myObject);
 					    }
 
-					    void detectsThrowableArgument(Exception exception) {
+					    void fatalThrowableArgument(Exception exception) {
 					        LOGGER.fatal("Failure", exception);
+					    }
+
+					    void fatalMethodReference(Optional<Object> value) {
+					        value.ifPresent(LOGGER::fatal);
+					    }
+
+					    void bareLevelFatalConstant() {
+					        Level level = Level.FATAL;
+					    }
+
+					    void logAtFatalLevel() {
+					        LOGGER.log(Level.FATAL, "boom");
 					    }
 					}
 					""",
 					"""
+					/*~~>*/import org.apache.log4j.Level;
 					import org.apache.log4j.Logger;
+
+					import java.util.Optional;
 
 					class Test {
 					    private static final Logger LOGGER = Logger.getLogger(Test.class);
 
-					    void detectsStringLiteral() {
-					        /*~~>*/LOGGER.fatal("Simple message");
+					    void fatalStringLiteral() {
+					        LOGGER.fatal("Simple message");
 					    }
 
-					    void detectsStringVariable(String message) {
-					        /*~~>*/LOGGER.fatal(message);
+					    void fatalStringVariable(String message) {
+					        LOGGER.fatal(message);
 					    }
 
-					    void detectsObjectArgument(Object myObject) {
-					        /*~~>*/LOGGER.fatal(myObject);
+					    void fatalObjectArgument(Object myObject) {
+					        LOGGER.fatal(myObject);
 					    }
 
-					    void detectsThrowableArgument(Exception exception) {
-					        /*~~>*/LOGGER.fatal("Failure", exception);
+					    void fatalThrowableArgument(Exception exception) {
+					        LOGGER.fatal("Failure", exception);
+					    }
+
+					    void fatalMethodReference(Optional<Object> value) {
+					        value.ifPresent(LOGGER::fatal);
+					    }
+
+					    void bareLevelFatalConstant() {
+					        Level level = /*~~>*/Level.FATAL;
+					    }
+
+					    void logAtFatalLevel() {
+					        LOGGER.log(/*~~>*/Level.FATAL, "boom");
 					    }
 					}
 					"""
@@ -113,10 +173,17 @@ class UsesLog4jFatalTest implements RewriteTest {
 		this.rewriteRun(
 				java(
 					"""
+					import org.apache.log4j.Level;
 					import org.apache.log4j.Logger;
+
+					import java.util.Optional;
 
 					class CustomLogger {
 					    void fatal(String message) {}
+					}
+
+					class CustomLevel {
+					    public static final String FATAL = "FATAL";
 					}
 
 					class Test {
@@ -130,8 +197,22 @@ class UsesLog4jFatalTest implements RewriteTest {
 					        LOGGER.error(message);
 					    }
 
+					    void doesNotDetectOtherLevelConstants() {
+					        Level error = Level.ERROR;
+					        Level debug = Level.DEBUG;
+					        LOGGER.log(Level.ERROR, "oops");
+					    }
+
+					    void doesNotDetectOtherLevelMethodReference(Optional<Object> value) {
+					        value.ifPresent(LOGGER::error);
+					    }
+
 					    void doesNotDetectUnrelatedFatal(String message) {
 					        custom.fatal(message);
+					    }
+
+					    void doesNotDetectUnrelatedFatalConstant() {
+					        String fatal = CustomLevel.FATAL;
 					    }
 					}
 					"""


### PR DESCRIPTION
- `UsesLog4jFatal` only matched `fatal(..)` invocations, so `LOGGER::fatal` and the `Level.FATAL`/`Priority.FATAL` constant slipped past the `DoesNotUseLog4jFatal` precondition and got migrated, losing FATAL severity.
- Detection now uses `UsesMethod` (which covers both invocations and method references) plus a field-access visitor for the constant, composed with `Preconditions.or` and shared with the precondition.
- No upstream OpenRewrite recipe covers these forms; tests cover each form (invocation, reference, `Level.FATAL`, `log(Level.FATAL, …)`) plus negatives.