### PR TITLE
Detect Log4j 1 object logging via method references

### DIFF
--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLogging.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLogging.java
@@ -17,22 +17,25 @@
 package io.liftwizard.rewrite.logging;
 
 import java.util.List;
+import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.marker.SearchResult;
 
 /**
- * Search recipe that finds Log4j 1.x logging calls where the message argument is not a String.
+ * Search recipe that finds Log4j 1.x logging usage where the message argument is not a String.
  *
  * <p>Log4j 1's {@code Category.info(Object)} accepts any Object, enabling structured logging
- * where appenders can inspect the argument's type via {@code instanceof}. Migrating such calls
+ * where appenders can inspect the argument's type via {@code instanceof}. Migrating such usage
  * to SLF4J (which only has {@code info(String)}) would either break compilation or silently
  * destroy structured logging if transformed to {@code info("{}", object)}.
  *
@@ -40,12 +43,23 @@ import org.openrewrite.marker.SearchResult;
  * are not structured object logging and migrate safely to SLF4J, which has a native
  * {@code error(String, Throwable)} overload.
  *
- * <p>This recipe is used as the basis for the {@link DoesNotUseLog4j1ObjectLogging} precondition,
- * which prevents the Log4j 1 to SLF4J migration from running on files that use this pattern.
+ * <p>Detection covers the forms a message can reach Log4j 1:
+ * <ul>
+ *     <li>level method invocations ({@code LOGGER.info(message)}) — message is the first argument;</li>
+ *     <li>level method references ({@code collection.forEach(LOGGER::info)}) — message type comes from
+ *         the functional interface.</li>
+ * </ul>
+ *
+ * <p>This recipe contributes the policy of which <em>message types</em> are unsafe to migrate. An
+ * unresolved message type is treated as an object, so the recipe (and the
+ * {@link DoesNotUseLog4j1ObjectLogging} precondition built on it) errs toward <em>not</em> migrating.
  */
 public final class UsesLog4j1ObjectLogging extends Recipe {
 
-	private static final List<MethodMatcher> LOG_MATCHERS = List.of(
+	private static final Set<String> METHOD_NAMES = Set.of("trace", "debug", "info", "warn", "error", "fatal");
+
+	/** Level methods whose message is the first argument. Both {@code Category} and {@code Logger} variants are matched so detection survives unresolvable {@code Logger extends Category} inheritance. */
+	private static final List<MethodMatcher> LEVEL_MATCHERS = List.of(
 		new MethodMatcher("org.apache.log4j.Category debug(..)", true),
 		new MethodMatcher("org.apache.log4j.Category info(..)", true),
 		new MethodMatcher("org.apache.log4j.Category warn(..)", true),
@@ -67,8 +81,9 @@ public final class UsesLog4j1ObjectLogging extends Recipe {
 	@Override
 	public String getDescription() {
 		return (
-			"Finds Log4j 1.x logging calls where the message argument is not a CharSequence. "
-			+ "These calls pass an Object directly (e.g., `LOGGER.info(myObject)`) "
+			"Finds Log4j 1.x logging where the message argument is not a CharSequence. "
+			+ "These pass an Object directly (e.g., `LOGGER.info(myObject)` "
+			+ "or `collection.forEach(LOGGER::info)`) "
 			+ "which allows appenders to inspect the object's type for structured logging. "
 			+ "CharSequence message arguments (e.g., String, StringBuilder) and Throwable "
 			+ "message arguments (e.g., `LOGGER.error(exception)`) are excluded "
@@ -86,21 +101,72 @@ public final class UsesLog4j1ObjectLogging extends Recipe {
 		@Override
 		public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
 			J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
-			if (m.getArguments().isEmpty() || m.getArguments().get(0) instanceof J.Empty) {
-				return m;
-			}
-			for (MethodMatcher matcher : LOG_MATCHERS) {
-				if (matcher.matches(m)) {
-					JavaType firstArgType = m.getArguments().get(0).getType();
-					if (
-						!isCharSequence(firstArgType) && !TypeUtils.isAssignableTo("java.lang.Throwable", firstArgType)
-					) {
-						return SearchResult.found(m);
-					}
-					break;
-				}
+			Expression message = messageArgument(m);
+			if (message != null && isObjectMessage(message.getType())) {
+				return SearchResult.found(m);
 			}
 			return m;
+		}
+
+		@Override
+		public J.MemberReference visitMemberReference(J.MemberReference memberReference, ExecutionContext ctx) {
+			J.MemberReference mr = super.visitMemberReference(memberReference, ctx);
+			if (isLoggingReference(mr) && isObjectMessage(consumedMessageType(mr))) {
+				return SearchResult.found(mr);
+			}
+			return mr;
+		}
+
+		/** The message argument of a Log4j 1 logging invocation, or {@code null} if {@code m} is not one. */
+		private static @Nullable Expression messageArgument(J.MethodInvocation m) {
+			if (!METHOD_NAMES.contains(m.getSimpleName())) {
+				return null;
+			}
+			if (m.getArguments().isEmpty() || m.getArguments().get(0) instanceof J.Empty) {
+				return null;
+			}
+			if (matchesAny(LEVEL_MATCHERS, m)) {
+				return m.getArguments().get(0);
+			}
+			return null;
+		}
+
+		/** Whether {@code mr} is a reference to a Log4j 1 logging method (e.g. {@code LOGGER::info}). */
+		private static boolean isLoggingReference(J.MemberReference mr) {
+			return (METHOD_NAMES.contains(mr.getReference().getSimpleName()) && matchesAny(LEVEL_MATCHERS, mr));
+		}
+
+		/**
+		 * The message type consumed by a logging method reference, read from the functional interface it
+		 * implements. Only a single-type-parameter SAM ({@code Consumer<T>}-shaped) identifies the consumed
+		 * type unambiguously; raw types, multi-parameter SAMs, and unresolved types return {@code null}.
+		 */
+		private static @Nullable JavaType consumedMessageType(J.MemberReference mr) {
+			if (
+				mr.getType() instanceof JavaType.Parameterized functionalInterface
+				&& functionalInterface.getTypeParameters().size() == 1
+			) {
+				return functionalInterface.getTypeParameters().get(0);
+			}
+			return null;
+		}
+
+		private static boolean matchesAny(List<MethodMatcher> matchers, Expression expression) {
+			for (MethodMatcher matcher : matchers) {
+				if (matcher.matches(expression)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/**
+		 * Whether the message type is a non-String, non-Throwable object — i.e. structured object logging
+		 * that does not migrate safely to SLF4J. An unresolved ({@code null}) type is treated as an object
+		 * so the precondition errs toward not migrating.
+		 */
+		private static boolean isObjectMessage(@Nullable JavaType type) {
+			return !isCharSequence(type) && !TypeUtils.isAssignableTo("java.lang.Throwable", type);
 		}
 
 		/**
@@ -110,7 +176,7 @@ public final class UsesLog4j1ObjectLogging extends Recipe {
 		 * does not match, while {@code StringBuilder} and {@code StringBuffer} are matched only by the
 		 * assignability check.
 		 */
-		private static boolean isCharSequence(JavaType type) {
+		private static boolean isCharSequence(@Nullable JavaType type) {
 			return TypeUtils.isString(type) || TypeUtils.isAssignableTo("java.lang.CharSequence", type);
 		}
 	}

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLoggingTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1ObjectLoggingTest.java
@@ -42,6 +42,8 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 					"""
 					import org.apache.log4j.Logger;
 
+					import java.util.function.Consumer;
+
 					class MyEvent {
 					    String name;
 					}
@@ -64,10 +66,24 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 					        LOGGER.error(obj);
 					        LOGGER.fatal(obj);
 					    }
+
+					    void detectsObjectMethodReference() {
+					        take(LOGGER::trace);
+					        take(LOGGER::debug);
+					        take(LOGGER::info);
+					        take(LOGGER::warn);
+					        take(LOGGER::error);
+					        take(LOGGER::fatal);
+					    }
+
+					    void take(Consumer<MyEvent> sink) {
+					    }
 					}
 					""",
 					"""
 					import org.apache.log4j.Logger;
+
+					import java.util.function.Consumer;
 
 					class MyEvent {
 					    String name;
@@ -91,6 +107,18 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 					        /*~~>*/LOGGER.error(obj);
 					        /*~~>*/LOGGER.fatal(obj);
 					    }
+
+					    void detectsObjectMethodReference() {
+					        take(/*~~>*/LOGGER::trace);
+					        take(/*~~>*/LOGGER::debug);
+					        take(/*~~>*/LOGGER::info);
+					        take(/*~~>*/LOGGER::warn);
+					        take(/*~~>*/LOGGER::error);
+					        take(/*~~>*/LOGGER::fatal);
+					    }
+
+					    void take(Consumer<MyEvent> sink) {
+					    }
 					}
 					"""
 				)
@@ -103,6 +131,8 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 				java(
 					"""
 					import org.apache.log4j.Logger;
+
+					import java.util.function.Consumer;
 
 					class Test {
 					    private static final Logger LOGGER = Logger.getLogger(Test.class);
@@ -126,6 +156,18 @@ class UsesLog4j1ObjectLoggingTest implements RewriteTest {
 
 					    void doesNotDetectStringBuilder(StringBuilder builder) {
 					        LOGGER.info(builder);
+					    }
+
+					    void doesNotDetectStringMethodReference() {
+					        take(LOGGER::trace);
+					        take(LOGGER::debug);
+					        take(LOGGER::info);
+					        take(LOGGER::warn);
+					        take(LOGGER::error);
+					        take(LOGGER::fatal);
+					    }
+
+					    void take(Consumer<String> sink) {
 					    }
 					}
 					"""


### PR DESCRIPTION
- `UsesLog4j1ObjectLogging` only matched level-method invocations, so object logging via method references (`collection.forEach(LOGGER::info)`) slipped past the `DoesNotUseLog4j1ObjectLogging` precondition and got migrated, destroying structured logging.
- Adds member-reference detection: the consumed message type is read from the functional interface the reference implements. Reference consumed-type inference trusts only single-type-parameter functional interfaces and conservatively flags otherwise.
- The recipe keeps only the object-message policy; an unresolved message type is treated as an object, so detection errs toward *not* migrating.
- Retains the severed-inheritance test guarding degraded-type detection; `mvn verify` green (spotless clean).
