### PR TITLE
feat(logging): skip Log4j 1 log(Priority, ..) calls in the SLF4J migration

### DIFF
--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/DoesNotUseLog4j1LogWithPriority.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/DoesNotUseLog4j1LogWithPriority.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.logging;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+/**
+ * Precondition recipe that matches files which do <em>not</em> use Log4j 1.x
+ * {@code log(Priority, ..)} logging.
+ *
+ * <p>This is the negation of {@link UsesLog4j1LogWithPriority}. It is intended to be used as a
+ * YAML {@code preconditions} entry so that a composite migration recipe (e.g., Log4j 1 to SLF4J)
+ * skips files that call the generic {@code log(Priority, ..)} method, which SLF4J cannot express
+ * and the upstream migration would otherwise leave as uncompilable code.
+ */
+public final class DoesNotUseLog4j1LogWithPriority extends Recipe {
+
+	@Override
+	public String getDisplayName() {
+		return "Does not use Log4j 1.x log(Priority, ..)";
+	}
+
+	@Override
+	public String getDescription() {
+		return (
+			"Precondition that matches source files which do not call the Log4j 1.x generic "
+			+ "`log(Priority, ..)` method. Files that use it (e.g., `LOGGER.log(Level.INFO, message)`) "
+			+ "are excluded, because SLF4J has no generic `log(level, ..)` method and migrating them "
+			+ "would produce uncompilable code."
+		);
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return Preconditions.not(UsesLog4j1LogWithPriority.logWithPriorityUsage());
+	}
+}

--- a/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1LogWithPriority.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/java/io/liftwizard/rewrite/logging/UsesLog4j1LogWithPriority.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.logging;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.search.UsesMethod;
+
+/**
+ * Search recipe that finds Log4j 1.x generic {@code log(Priority, ..)} logging usage.
+ *
+ * <p>Log4j 1's {@code Category.log(Priority, Object, ..)} dispatches at a level supplied as a
+ * {@code Priority} argument. SLF4J has no generic {@code log(level, ..)} method — only the fixed
+ * {@code trace}/{@code debug}/{@code info}/{@code warn}/{@code error} family — so the level dispatch
+ * has no equivalent. The upstream Log4j 1 to SLF4J migration does not lower these calls; it rewrites
+ * the logger type to {@code org.slf4j.Logger} but leaves the {@code log(..)} invocation in place,
+ * producing code that no longer compiles. This is true regardless of the message type, so unlike
+ * {@link UsesLog4j1ObjectLogging} this recipe flags every {@code log(Priority, ..)} call rather than
+ * only those with an Object message.
+ *
+ * <p>Detection uses {@link UsesMethod}, which matches every call form — direct invocations
+ * ({@code LOGGER.log(Level.INFO, message)}) and method references ({@code LOGGER::log}) — via the
+ * compilation unit's resolved method types.
+ *
+ * <p>This recipe is the basis for the {@link DoesNotUseLog4j1LogWithPriority} precondition, which
+ * prevents the Log4j 1 to SLF4J migration from running on files that use this pattern.
+ */
+public final class UsesLog4j1LogWithPriority extends Recipe {
+
+	@Override
+	public String getDisplayName() {
+		return "Find Log4j 1.x log(Priority, ..) usage";
+	}
+
+	@Override
+	public String getDescription() {
+		return (
+			"Finds Log4j 1.x calls to the generic `log(Priority, ..)` method "
+			+ "(e.g., `LOGGER.log(Level.INFO, message)` or `LOGGER::log`). SLF4J has no generic "
+			+ "`log(level, ..)` method, so these cannot be migrated automatically and the upstream "
+			+ "migration leaves them as uncompilable calls on an `org.slf4j.Logger`."
+		);
+	}
+
+	@Override
+	public TreeVisitor<?, ExecutionContext> getVisitor() {
+		return logWithPriorityUsage();
+	}
+
+	/**
+	 * Builds the visitor that flags any Log4j 1.x {@code log(Priority, ..)} usage. Shared with
+	 * {@link DoesNotUseLog4j1LogWithPriority} so the precondition stays in sync with this recipe's
+	 * detection. {@code Logger extends Category} and inherits {@code log(..)}, so matching the
+	 * declaring type with overrides covers both.
+	 */
+	static TreeVisitor<?, ExecutionContext> logWithPriorityUsage() {
+		return new UsesMethod<>("org.apache.log4j.Category log(..)", true);
+	}
+}

--- a/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/logging/log4j-1-to-slf4j.yml
+++ b/liftwizard-utility/liftwizard-rewrite/src/main/resources/META-INF/rewrite/logging/log4j-1-to-slf4j.yml
@@ -23,12 +23,15 @@ description: >-
   Unlike the upstream recipe, this version skips files that pass non-String
   Objects to Log4j 1 logging methods (e.g., LOGGER.info(myObject)),
   preserving structured logging capabilities. It also skips files that log at
-  the FATAL level (e.g., LOGGER.fatal(message)), which has no SLF4J equivalent.
-  Files with object logging or fatal logging remain on Log4j 1 and must be
-  migrated manually.
+  the FATAL level (e.g., LOGGER.fatal(message)), which has no SLF4J equivalent,
+  and files that call the generic log(Priority, ..) method
+  (e.g., LOGGER.log(Level.INFO, message)), which SLF4J cannot express.
+  Files with object logging, fatal logging, or log(Priority, ..) calls remain
+  on Log4j 1 and must be migrated manually.
 preconditions:
   - io.liftwizard.rewrite.logging.DoesNotUseLog4j1ObjectLogging
   - io.liftwizard.rewrite.logging.DoesNotUseLog4jFatal
+  - io.liftwizard.rewrite.logging.DoesNotUseLog4j1LogWithPriority
 recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.log4j.MDC

--- a/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1LogWithPriorityTest.java
+++ b/liftwizard-utility/liftwizard-rewrite/src/test/java/io/liftwizard/rewrite/logging/UsesLog4j1LogWithPriorityTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 Craig Motlin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.liftwizard.rewrite.logging;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class UsesLog4j1LogWithPriorityTest implements RewriteTest {
+
+	@Override
+	public void defaults(RecipeSpec spec) {
+		spec
+			.recipe(new UsesLog4j1LogWithPriority())
+			.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "reload4j"));
+	}
+
+	@DocumentExample
+	@Test
+	void replacePatterns() {
+		this.rewriteRun(
+				java(
+					"""
+					import org.apache.log4j.Level;
+					import org.apache.log4j.Logger;
+					import org.apache.log4j.Priority;
+
+					import java.util.function.BiConsumer;
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+
+					    void staticStandardLevel() {
+					        LOGGER.log(Level.INFO, "hello");
+					    }
+
+					    void objectMessage(Object myObject) {
+					        LOGGER.log(Level.INFO, myObject);
+					    }
+
+					    void dynamicPriority(Priority priority, String message) {
+					        LOGGER.log(priority, message);
+					    }
+
+					    void withThrowable(Exception exception) {
+					        LOGGER.log(Level.ERROR, "boom", exception);
+					    }
+
+					    void methodReference() {
+					        BiConsumer<Priority, Object> ref = LOGGER::log;
+					    }
+					}
+					""",
+					"""
+					/*~~>*/import org.apache.log4j.Level;
+					import org.apache.log4j.Logger;
+					import org.apache.log4j.Priority;
+
+					import java.util.function.BiConsumer;
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+
+					    void staticStandardLevel() {
+					        LOGGER.log(Level.INFO, "hello");
+					    }
+
+					    void objectMessage(Object myObject) {
+					        LOGGER.log(Level.INFO, myObject);
+					    }
+
+					    void dynamicPriority(Priority priority, String message) {
+					        LOGGER.log(priority, message);
+					    }
+
+					    void withThrowable(Exception exception) {
+					        LOGGER.log(Level.ERROR, "boom", exception);
+					    }
+
+					    void methodReference() {
+					        BiConsumer<Priority, Object> ref = LOGGER::log;
+					    }
+					}
+					"""
+				)
+			);
+	}
+
+	@Test
+	void doNotReplaceInvalidPatterns() {
+		this.rewriteRun(
+				java(
+					"""
+					import org.apache.log4j.Level;
+					import org.apache.log4j.Logger;
+
+					class CustomLogger {
+					    void log(String message) {}
+					}
+
+					class Test {
+					    private static final Logger LOGGER = Logger.getLogger(Test.class);
+					    private final CustomLogger custom = new CustomLogger();
+
+					    void doesNotDetectLevelMethods(String message) {
+					        LOGGER.debug(message);
+					        LOGGER.info(message);
+					        LOGGER.warn(message);
+					        LOGGER.error(message);
+					    }
+
+					    void doesNotDetectBareLevelConstant() {
+					        Level level = Level.INFO;
+					    }
+
+					    void doesNotDetectUnrelatedLog(String message) {
+					        custom.log(message);
+					    }
+					}
+					"""
+				)
+			);
+	}
+}


### PR DESCRIPTION
- **What**: Adds `UsesLog4j1LogWithPriority` (matches every `Category/Logger log(..)` call via `UsesMethod`) and its `DoesNotUseLog4j1LogWithPriority` negation. The precondition is wired into `log4j-1-to-slf4j.yml` so affected files stay on Log4j 1 for manual migration.
- **Why**: SLF4J has no generic `log(level, ..)` method, so Log4j 1's `Category.log(Priority, ..)` dispatch has no equivalent. Verified against `rewrite-logging-frameworks:3.28.0` that the upstream chain leaves the `log(...)` call on an `org.slf4j.Logger`, producing code that no longer compiles — regardless of message type, so even a string-message call that slips past the existing preconditions is now caught.
- **Tests**: `UsesLog4j1LogWithPriorityTest` covers positive forms (direct calls, 3-arg with throwable, dynamic priority, object message, method reference) and negatives (level methods, bare `Level` constant, unrelated `log`). Full `liftwizard-rewrite` suite is green (263 tests).
