### PR TITLE
Upgrade Reladomo to 18.1.0 and honor UTC test-data conversion.

### DIFF
--- a/liftwizard-example-resources/src/main/resources/reladomo/Person.xml
+++ b/liftwizard-example-resources/src/main/resources/reladomo/Person.xml
@@ -16,6 +16,7 @@
             defaultIfNotSpecified="[com.gs.fw.common.mithra.util.DefaultInfinityTimestamp.getDefaultInfinity()]"
             futureExpiringRowsExist="true"
             isProcessingDate="true"
+            timezoneConversion="convert-to-utc"
             finalGetter="true"
             fromColumnName="system_from"
             toColumnName="system_to" />

--- a/liftwizard-maven-build/liftwizard-dependencies/pom.xml
+++ b/liftwizard-maven-build/liftwizard-dependencies/pom.xml
@@ -141,7 +141,7 @@
             <dependency>
                 <groupId>com.goldmansachs.reladomo</groupId>
                 <artifactId>reladomo</artifactId>
-                <version>18.0.0</version>
+                <version>18.1.0</version>
             </dependency>
 
             <dependency>
@@ -159,7 +159,7 @@
             <dependency>
                 <groupId>com.goldmansachs.reladomo</groupId>
                 <artifactId>reladomo-gen-util</artifactId>
-                <version>18.0.0</version>
+                <version>18.1.0</version>
             </dependency>
 
             <dependency>

--- a/liftwizard-reladomo/liftwizard-reladomo-csv-test-extension/src/main/java/io/liftwizard/reladomo/csv/test/extension/CsvTestDataParser.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-csv-test-extension/src/main/java/io/liftwizard/reladomo/csv/test/extension/CsvTestDataParser.java
@@ -27,6 +27,8 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -196,8 +198,7 @@ public class CsvTestDataParser {
 		@Nonnull String value
 	) {
 		if (attribute instanceof TimestampAttribute timestampAttribute) {
-			Instant instant = Instant.parse(value);
-			Timestamp timestamp = Timestamp.from(instant);
+			Timestamp timestamp = parseTimestamp(timestampAttribute, value);
 			timestampAttribute.setTimestampValue(dataObject, timestamp);
 		} else if (attribute instanceof DateAttribute dateAttribute) {
 			LocalDate localDate = LocalDate.parse(value);
@@ -218,6 +219,20 @@ public class CsvTestDataParser {
 		} else {
 			throw new UnsupportedOperationException("Unsupported attribute type: " + attribute.getClass().getName());
 		}
+	}
+
+	static Timestamp parseTimestamp(TimestampAttribute<?> timestampAttribute, String value) {
+		Instant instant = Instant.parse(value);
+		Timestamp timestamp = Timestamp.from(instant);
+		LocalDateTime utcDateTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+		if (
+			timestampAttribute.isAsOfAttributeTo()
+			&& (timestamp.equals(timestampAttribute.getAsOfAttributeInfinity())
+				|| utcDateTime.equals(timestampAttribute.getAsOfAttributeInfinity().toLocalDateTime()))
+		) {
+			return timestampAttribute.getAsOfAttributeInfinity();
+		}
+		return timestampAttribute.requiresConversionFromUtc() ? Timestamp.valueOf(utcDateTime) : timestamp;
 	}
 
 	@Nonnull

--- a/liftwizard-reladomo/liftwizard-reladomo-csv-test-extension/src/test/java/io/liftwizard/reladomo/csv/test/extension/CsvTestDataParserTest.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-csv-test-extension/src/test/java/io/liftwizard/reladomo/csv/test/extension/CsvTestDataParserTest.java
@@ -17,7 +17,7 @@
 package io.liftwizard.reladomo.csv.test.extension;
 
 import java.sql.Timestamp;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.example.helloworld.core.PersonData;
@@ -103,14 +103,14 @@ class CsvTestDataParserTest {
 		expectedAlice.setId(1L);
 		expectedAlice.setFullName("Alice Smith");
 		expectedAlice.setJobTitle("Engineer");
-		expectedAlice.setSystemFrom(Timestamp.from(Instant.parse("2024-01-01T00:00:00.000Z")));
+		expectedAlice.setSystemFrom(Timestamp.valueOf(LocalDateTime.parse("2024-01-01T00:00:00.000")));
 		expectedAlice.setSystemTo(PersonFinder.systemTo().getAsOfAttributeInfinity());
 
 		var expectedBob = new PersonData();
 		expectedBob.setId(2L);
 		expectedBob.setFullName("Bob Jones");
 		expectedBob.setJobTitle("Manager");
-		expectedBob.setSystemFrom(Timestamp.from(Instant.parse("2024-01-15T00:00:00.000Z")));
+		expectedBob.setSystemFrom(Timestamp.valueOf(LocalDateTime.parse("2024-01-15T00:00:00.000")));
 		expectedBob.setSystemTo(PersonFinder.systemTo().getAsOfAttributeInfinity());
 
 		var parser = new CsvTestDataParser("test-data/com.example.helloworld.core.Person.csv");

--- a/liftwizard-reladomo/liftwizard-reladomo-json-test-extension/src/main/java/io/liftwizard/reladomo/json/test/extension/JsonTestDataParser.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-json-test-extension/src/main/java/io/liftwizard/reladomo/json/test/extension/JsonTestDataParser.java
@@ -18,6 +18,11 @@ package io.liftwizard.reladomo.json.test.extension;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -27,12 +32,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.gs.fw.common.mithra.MithraDataObject;
+import com.gs.fw.common.mithra.attribute.TimestampAttribute;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JsonTestDataParser {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(JsonTestDataParser.class);
+	private static final Class<?>[] NO_PARAMS = {};
 
 	@Nonnull
 	private final String filename;
@@ -87,9 +94,47 @@ public class JsonTestDataParser {
 			String dataClassName = this.className + "Data";
 			Class<?> dataClass = Class.forName(dataClassName);
 			this.dataObjects = objectMapper.readerForListOf(dataClass).readValue(arrayNode);
-		} catch (ClassNotFoundException | IOException e) {
+			this.convertTimestampsFromUtc(arrayNode);
+		} catch (IOException | ReflectiveOperationException e) {
 			throw new RuntimeException("Error reading JSON file: " + this.filename, e);
 		}
+	}
+
+	private void convertTimestampsFromUtc(ArrayNode arrayNode)
+		throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+		Class<?> finderClass = Class.forName(this.className + "Finder");
+		for (var rowIndex = 0; rowIndex < arrayNode.size(); rowIndex++) {
+			JsonNode row = arrayNode.get(rowIndex);
+			MithraDataObject dataObject = this.dataObjects.get(rowIndex);
+			var fieldNames = row.fieldNames();
+			while (fieldNames.hasNext()) {
+				String fieldName = fieldNames.next();
+				Method attributeMethod = finderClass.getMethod(fieldName, NO_PARAMS);
+				Object attribute = attributeMethod.invoke(null);
+				if (attribute instanceof TimestampAttribute timestampAttribute) {
+					Timestamp timestamp = timestampAttribute.valueOf(dataObject);
+					timestampAttribute.setTimestampValue(
+						dataObject,
+						convertTimestampFromUtc(timestampAttribute, timestamp)
+					);
+				}
+			}
+		}
+	}
+
+	private static Timestamp convertTimestampFromUtc(TimestampAttribute<?> timestampAttribute, Timestamp timestamp) {
+		if (timestamp == null) {
+			return null;
+		}
+		LocalDateTime utcDateTime = LocalDateTime.ofInstant(timestamp.toInstant(), ZoneOffset.UTC);
+		if (
+			timestampAttribute.isAsOfAttributeTo()
+			&& (timestamp.equals(timestampAttribute.getAsOfAttributeInfinity())
+				|| utcDateTime.equals(timestampAttribute.getAsOfAttributeInfinity().toLocalDateTime()))
+		) {
+			return timestampAttribute.getAsOfAttributeInfinity();
+		}
+		return timestampAttribute.requiresConversionFromUtc() ? Timestamp.valueOf(utcDateTime) : timestamp;
 	}
 
 	@Nonnull

--- a/liftwizard-reladomo/liftwizard-reladomo-json-test-extension/src/test/java/io/liftwizard/reladomo/json/test/extension/JsonTestDataExtensionTest.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-json-test-extension/src/test/java/io/liftwizard/reladomo/json/test/extension/JsonTestDataExtensionTest.java
@@ -72,7 +72,7 @@ class JsonTestDataExtensionTest {
 
 		Instant aliceSystemFrom = Instant.parse("2024-01-01T00:00:00.000Z");
 		Instant bobSystemFrom = Instant.parse("2024-01-15T00:00:00.000Z");
-		Instant infinityInstant = Instant.parse("9999-12-01T23:59:00.000Z");
+		Instant infinityInstant = PersonFinder.systemTo().getAsOfAttributeInfinity().toInstant();
 
 		assertThat(alice)
 			.isNotNull()

--- a/liftwizard-reladomo/liftwizard-reladomo-json-test-extension/src/test/java/io/liftwizard/reladomo/json/test/extension/JsonTestDataParserTest.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-json-test-extension/src/test/java/io/liftwizard/reladomo/json/test/extension/JsonTestDataParserTest.java
@@ -17,14 +17,16 @@
 package io.liftwizard.reladomo.json.test.extension;
 
 import java.sql.Timestamp;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.example.helloworld.core.PersonData;
+import com.example.helloworld.core.PersonFinder;
 import com.gs.fw.common.mithra.MithraDataObject;
 import io.liftwizard.reladomo.test.extension.ExecuteSqlExtension;
 import io.liftwizard.reladomo.test.extension.ReladomoInitializeExtension;
 import io.liftwizard.reladomo.test.extension.ReladomoPurgeAllExtension;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -89,25 +91,32 @@ class JsonTestDataParserTest {
 
 	@Test
 	void populatesDataObjectsWithCorrectValues() {
-		var expectedAlice = new PersonData();
-		expectedAlice.setId(1L);
-		expectedAlice.setFullName("Alice Smith");
-		expectedAlice.setJobTitle("Engineer");
-		expectedAlice.setSystemFrom(Timestamp.from(Instant.parse("2024-01-01T00:00:00.000Z")));
-		expectedAlice.setSystemTo(Timestamp.from(Instant.parse("9999-12-01T23:59:00.000Z")));
-
-		var expectedBob = new PersonData();
-		expectedBob.setId(2L);
-		expectedBob.setFullName("Bob Jones");
-		expectedBob.setJobTitle("Manager");
-		expectedBob.setSystemFrom(Timestamp.from(Instant.parse("2024-01-15T00:00:00.000Z")));
-		expectedBob.setSystemTo(Timestamp.from(Instant.parse("9999-12-01T23:59:00.000Z")));
-
 		var parser = new JsonTestDataParser("test-data/com.example.helloworld.core.Person.json");
 		List<MithraDataObject> dataObjects = parser.getDataObjects();
 
 		assertThat(dataObjects)
-			.usingRecursiveFieldByFieldElementComparator()
-			.containsExactly(expectedAlice, expectedBob);
+			.extracting(
+				(dataObject) -> ((PersonData) dataObject).getId(),
+				(dataObject) -> ((PersonData) dataObject).getFullName(),
+				(dataObject) -> ((PersonData) dataObject).getJobTitle(),
+				(dataObject) -> ((PersonData) dataObject).getSystemFrom(),
+				(dataObject) -> ((PersonData) dataObject).getSystemTo()
+			)
+			.containsExactly(
+				Tuple.tuple(
+					1L,
+					"Alice Smith",
+					"Engineer",
+					Timestamp.valueOf(LocalDateTime.parse("2024-01-01T00:00:00.000")),
+					PersonFinder.systemTo().getAsOfAttributeInfinity()
+				),
+				Tuple.tuple(
+					2L,
+					"Bob Jones",
+					"Manager",
+					Timestamp.valueOf(LocalDateTime.parse("2024-01-15T00:00:00.000")),
+					PersonFinder.systemTo().getAsOfAttributeInfinity()
+				)
+			);
 	}
 }

--- a/liftwizard-reladomo/liftwizard-reladomo-rollback/src/test/java/io/liftwizard/reladomo/rollback/ReladomoTemporalRollbackTest.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-rollback/src/test/java/io/liftwizard/reladomo/rollback/ReladomoTemporalRollbackTest.java
@@ -89,14 +89,15 @@ class ReladomoTemporalRollbackTest {
 		Person alice = PersonFinder.findOne(PersonFinder.id().eq(1L).and(PersonFinder.system().equalsEdgePoint()));
 		assertThat(alice).isNotNull();
 		assertThat(alice.getFullName()).isEqualTo("Alice");
-		assertThat(alice.getSystemTo().toInstant().atZone(ZoneOffset.UTC).getYear()).isEqualTo(9999);
+		assertThat(alice.getSystemFrom().toInstant()).isEqualTo(Instant.parse("2024-01-01T00:00:00Z"));
+		assertThat(alice.getSystemTo()).isEqualTo(PersonFinder.systemTo().getAsOfAttributeInfinity());
 
 		// Bob should now be active (system_to restored to infinity)
 		Person bob = PersonFinder.findOne(PersonFinder.id().eq(2L).and(PersonFinder.system().equalsEdgePoint()));
 		assertThat(bob).isNotNull();
 		assertThat(bob.getFullName()).isEqualTo("Bob");
 		// Bob's system_to should now be infinity (restored from 2024-06-15)
-		assertThat(bob.getSystemTo().toInstant().atZone(ZoneOffset.UTC).getYear()).isEqualTo(9999);
+		assertThat(bob.getSystemTo()).isEqualTo(PersonFinder.systemTo().getAsOfAttributeInfinity());
 
 		// Charlie should not exist (purged because created after rollback date)
 		Person charlie = PersonFinder.findOne(PersonFinder.id().eq(3L).and(PersonFinder.system().equalsEdgePoint()));

--- a/liftwizard-reladomo/liftwizard-reladomo-simulated-sequence/pom.xml
+++ b/liftwizard-reladomo/liftwizard-reladomo-simulated-sequence/pom.xml
@@ -69,7 +69,7 @@
                     <dependency>
                         <groupId>com.goldmansachs.reladomo</groupId>
                         <artifactId>reladomo-gen-util</artifactId>
-                        <version>18.0.0</version>
+                        <version>18.1.0</version>
                     </dependency>
 
                 </dependencies>

--- a/liftwizard-reladomo/liftwizard-reladomo-test-data-parser/src/main/java/io/liftwizard/reladomo/test/data/parser/UtcMithraParsedData.java
+++ b/liftwizard-reladomo/liftwizard-reladomo-test-data-parser/src/main/java/io/liftwizard/reladomo/test/data/parser/UtcMithraParsedData.java
@@ -17,22 +17,26 @@
 package io.liftwizard.reladomo.test.data.parser;
 
 import java.io.StreamTokenizer;
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.TimeZone;
 
 import com.gs.fw.common.mithra.attribute.Attribute;
 import com.gs.fw.common.mithra.attribute.NumericAttribute;
+import com.gs.fw.common.mithra.attribute.TimestampAttribute;
 import com.gs.fw.common.mithra.util.fileparser.MithraParsedData;
 
 /**
  * A UTC-aware version of Reladomo's {@link MithraParsedData}.
  *
  * <p>The standard {@code MithraParsedData} parses timestamps using the JVM's default timezone.
- * This class overrides {@link #parseData(StreamTokenizer, int, Object)} to always parse
- * timestamps in UTC, which is necessary for bitemporal data using
- * {@code UtcInfinityTimestamp}.</p>
+ * This class overrides {@link #parseData(StreamTokenizer, int, Object)} to parse timestamp
+ * values in UTC. Reladomo as-of infinity values are the exception because they are
+ * JVM-local wall-clock sentinels.</p>
  *
  * @see MithraParsedData
  */
@@ -66,7 +70,7 @@ public class UtcMithraParsedData extends MithraParsedData {
 					attribute.parseWordAndSet(word, currentData, st.lineno());
 				}
 			}
-			case '"' -> attribute.parseStringAndSet(st.sval, currentData, st.lineno(), this.utcDateFormat);
+			case '"' -> this.parseStringAndSet(attribute, st.sval, currentData, st.lineno());
 			case StreamTokenizer.TT_EOL -> throw new RuntimeException("should never get here");
 			case StreamTokenizer.TT_EOF -> throw new ParseException("Unexpected end of file", st.lineno());
 			default -> {
@@ -84,5 +88,29 @@ public class UtcMithraParsedData extends MithraParsedData {
 				);
 			}
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private void parseStringAndSet(Attribute attribute, String value, Object currentData, int lineNumber)
+		throws ParseException {
+		if (attribute instanceof TimestampAttribute timestampAttribute) {
+			Timestamp timestamp = this.parseTimestamp(timestampAttribute, value);
+			timestampAttribute.setTimestampValue(currentData, timestamp);
+			return;
+		}
+		attribute.parseStringAndSet(value, currentData, lineNumber, this.utcDateFormat);
+	}
+
+	private Timestamp parseTimestamp(TimestampAttribute<?> timestampAttribute, String value) throws ParseException {
+		var timestamp = new Timestamp(this.utcDateFormat.parse(value).getTime());
+		LocalDateTime utcDateTime = LocalDateTime.ofInstant(timestamp.toInstant(), ZoneOffset.UTC);
+		if (
+			timestampAttribute.isAsOfAttributeTo()
+			&& (timestamp.equals(timestampAttribute.getAsOfAttributeInfinity())
+				|| utcDateTime.equals(timestampAttribute.getAsOfAttributeInfinity().toLocalDateTime()))
+		) {
+			return timestampAttribute.getAsOfAttributeInfinity();
+		}
+		return timestampAttribute.requiresConversionFromUtc() ? Timestamp.valueOf(utcDateTime) : timestamp;
 	}
 }


### PR DESCRIPTION
## Summary

- Upgrade the Reladomo runtime and generator utility dependencies from 18.0.0 to the production 18.1.0 release.
- Make CSV, JSON, and text test-data parsing honor each timestamp attribute's `CONVERT_TO_UTC` setting.
- Preserve the exact configured Reladomo infinity sentinel while converting ordinary external UTC instants to Reladomo's internal local-wall timestamp representation.
- Keep the existing public API and avoid any unpublished Reladomo insertion API or snapshot dependency.

## Timestamp contract

For an attribute configured with `timezoneConversion="convert-to-utc"`, external values such as `2001-01-03T23:59:59Z` are represented in memory using the equivalent local wall clock before Reladomo performs its database conversion. In `America/New_York`, that internal value is `2001-01-03 18:59:59`; the database round trip remains the original `2001-01-03T23:59:59Z`.

Infinity is handled separately: parsers retain the finder/configured Reladomo infinity timestamp exactly rather than applying ordinary timestamp conversion to it.

## Validation

- Focused CSV and rollback dependency graph passed in `America/New_York` and `UTC`.
- JSON dependency graph passed in `America/New_York` and `UTC`.
- Full 169-module repository precommit passed, including tests, formatting, Checkstyle, dependency analysis, and Javadocs.
- Full snapshot install completed successfully for downstream Klass and Factorio School validation.

This PR uses released Reladomo 18.1.0 and does not depend on the unreleased H2 work in goldmansachs/reladomo#256.
